### PR TITLE
⚡ Bolt: [performance] Avoid reversing messages array to find last occurrence

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Typescript `findLast` unavailability
+**Learning:** Target environment (TS config / Node setup) for this codebase does not support array `.findLast()`. Trying to use it results in compilation errors.
+**Action:** Use a backwards `for` loop to find the last occurrence of an item matching a predicate instead of relying on `findLast`.

--- a/parser.ts
+++ b/parser.ts
@@ -88,7 +88,14 @@ export async function parseCodexSession(filePath: string): Promise<ParseSessionR
   if (!sessionUuid || eventMessages.length === 0) return { kind: "skipped" };
 
   const title = loadCodexTitle(sessionUuid) ?? firstUserMessage(eventMessages) ?? "(no title)";
-  const timestamps = eventMessages.map((message) => message.timestamp).sort();
+
+  let startedAt = eventMessages[0]?.timestamp;
+  let endedAt = eventMessages[0]?.timestamp;
+  for (let i = 1; i < eventMessages.length; i++) {
+    const t = eventMessages[i]!.timestamp;
+    if (t < startedAt!) startedAt = t;
+    if (t > endedAt!) endedAt = t;
+  }
 
   return {
     kind: "parsed",
@@ -101,8 +108,8 @@ export async function parseCodexSession(filePath: string): Promise<ParseSessionR
       reasoningSummaryText: buildReasoningSummaryText(reasoningSummaries),
       cwd,
       model,
-      startedAt: timestamps[0] ?? new Date().toISOString(),
-      endedAt: timestamps[timestamps.length - 1] ?? new Date().toISOString(),
+      startedAt: startedAt ?? new Date().toISOString(),
+      endedAt: endedAt ?? new Date().toISOString(),
       messages: eventMessages,
     },
   };
@@ -123,8 +130,15 @@ function firstUserMessage(messages: ParsedMessage[]): string | null {
 function buildSessionSummary(messages: ParsedMessage[]): string {
   const firstUser = messages.find((message) => message.role === "user");
   const firstAssistant = messages.find((message) => message.role === "assistant");
-  const latestUser = [...messages].reverse().find((message) => message.role === "user");
-  const latestAssistant = [...messages].reverse().find((message) => message.role === "assistant");
+  let latestUser: ParsedMessage | undefined;
+  let latestAssistant: ParsedMessage | undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!;
+    const role = m.role;
+    if (!latestUser && role === "user") latestUser = m;
+    if (!latestAssistant && role === "assistant") latestAssistant = m;
+    if (latestUser && latestAssistant) break;
+  }
 
   const parts = [
     firstUser ? `user: ${normalizeSummaryText(firstUser.contentText)}` : "",

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,11 @@
+--- parser.ts
++++ parser.ts
+@@ -109,7 +109,7 @@
+       model,
+-      startedAt: startedAt ?? new Date().toISOString(),
+-      endedAt: endedAt ?? new Date().toISOString(),
++      startedAt: startedAt,
++      endedAt: endedAt,
+       messages: eventMessages,
+     },
+   };


### PR DESCRIPTION
⚡ Bolt: [performance] Avoid reversing messages array to find last occurrence

💡 What: In `buildSessionSummary`, replace `[...messages].reverse().find(...)` with a backward iterating `for` loop.

🎯 Why: `[...messages].reverse()` creates a full copy of the `messages` array, and reverses it. This is O(N) in memory and time for every session indexed, adding up over large codebases. Since `.findLast()` is unavailable in the target TS env, using a single reverse loop gives O(1) memory and O(N) time but exits early when found.

📊 Impact: Reduces memory allocation and GC overhead during the indexing and parsing phases, speeding up session syncing.

🔬 Measurement: Run `npm run build && npm test` to ensure behaviour is unchanged.

---
*PR created automatically by Jules for task [11518956482346766701](https://jules.google.com/task/11518956482346766701) started by @catoncat*