### PR TITLE
⚡ Bolt: Replace timestamp sort with O(N) min/max tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2023-10-27 - Date parsing overhead in sort loops
 **Learning:** Found that using `Date.parse(isoString)` inside `Array.prototype.sort()` callbacks is highly inefficient. Since ISO 8601 string formatting preserves lexicographical order for dates and times, parsing dates over and over again for comparisons is pure overhead.
 **Action:** Use direct string comparisons (`>` and `<`) for ISO 8601 strings, especially in loops and sorts. It is approximately 40x faster and requires zero memory allocations.
+## 2025-05-03 - Avoid array mapping and sorting for Min/Max
+**Learning:** Found a performance bottleneck where an array was mapped and then sorted (`arr.map(fn).sort()`) just to extract the minimum and maximum elements. This creates unnecessary O(N) memory allocations and O(N log N) computational overhead.
+**Action:** Replace `map().sort()` when extracting extremes by using a single loop (`for...of`) to track min and max values. This executes in O(N) time with O(1) space.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -87,7 +87,17 @@ export async function parseCodexSession(filePath: string): Promise<ParseSessionR
   if (!sessionUuid || eventMessages.length === 0) return { kind: "skipped" };
 
   const title = firstUserMessage(eventMessages) ?? "(no title)";
-  const timestamps = eventMessages.map((message) => message.timestamp).sort();
+
+  // OPTIMIZATION: Track min/max timestamps in a single O(N) pass.
+  // Avoids O(N) array allocation from map() and O(N log N) overhead from sort().
+  let minTimestamp: string | null = null;
+  let maxTimestamp: string | null = null;
+  for (const message of eventMessages) {
+    const ts = message.timestamp;
+    if (!ts) continue;
+    if (!minTimestamp || ts < minTimestamp) minTimestamp = ts;
+    if (!maxTimestamp || ts > maxTimestamp) maxTimestamp = ts;
+  }
 
   return {
     kind: "parsed",
@@ -100,8 +110,8 @@ export async function parseCodexSession(filePath: string): Promise<ParseSessionR
       reasoningSummaryText: buildReasoningSummaryText(reasoningSummaries),
       cwd,
       model,
-      startedAt: timestamps[0] ?? new Date().toISOString(),
-      endedAt: timestamps[timestamps.length - 1] ?? new Date().toISOString(),
+      startedAt: minTimestamp ?? new Date().toISOString(),
+      endedAt: maxTimestamp ?? new Date().toISOString(),
       messages: eventMessages,
     },
   };


### PR DESCRIPTION
What:
Replaced `Array.prototype.map().sort()` with a single O(N) loop to track the minimum (`startedAt`) and maximum (`endedAt`) timestamps in `src/parser.ts`.

Why:
The previous implementation performed an O(N) array allocation to map timestamps and an O(N log N) `.sort()` operation simply to extract the min and max elements. ISO 8601 timestamps can be safely compared lexicographically, so finding the min/max in a single O(N) loop with O(1) space removes this sorting overhead.

Impact:
Avoids intermediate array allocation and replaces an O(N log N) sorting step with an O(N) single pass, reducing memory allocation and improving performance on large log sessions.

Measurement:
Can be verified visually by code inspection or by profiling `cxs find` / sync over large sets of parsed Codex JSONL sessions where the number of messages per session is significant.

---
*PR created automatically by Jules for task [2493980840707041346](https://jules.google.com/task/2493980840707041346) started by @catoncat*