### PR TITLE
🧪 test: add coverage for sync-lock JSON parse failure

### DIFF
--- a/src/sync-lock.test.ts
+++ b/src/sync-lock.test.ts
@@ -60,6 +60,28 @@ describe("tryRemoveStaleLock", () => {
     expect(removed).toBe(false);
     expect(existsSync(lockPath)).toBe(true);
   });
+
+  test("returns true when the lock file contains malformed JSON", () => {
+    const lockPath = makeLockPath();
+    const expected = { pid: 4242, createdAt: "2026-04-27T00:00:00.000Z" };
+    writeFileSync(lockPath, "{ malformed JSON");
+
+    const removed = tryRemoveStaleLock(lockPath, expected);
+
+    expect(removed).toBe(true);
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  test("returns true when the lock file contains valid JSON but invalid structure", () => {
+    const lockPath = makeLockPath();
+    const expected = { pid: 4242, createdAt: "2026-04-27T00:00:00.000Z" };
+    writeFileSync(lockPath, JSON.stringify({ pid: "not a number" }));
+
+    const removed = tryRemoveStaleLock(lockPath, expected);
+
+    expect(removed).toBe(true);
+    expect(existsSync(lockPath)).toBe(true);
+  });
 });
 
 function makeLockPath(): string {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `tryRemoveStaleLock` function lacked an error test to verify its behavior when a lock file contains a malformed JSON format or invalid structure. `readLockInfo` catches parsing errors and returns `null`, and `tryRemoveStaleLock` gracefully handles it by returning `true`. This testing gap is now addressed.

📊 **Coverage:** What scenarios are now tested
1. **Malformed JSON:** The lock file contains an incomplete or invalid JSON string (`"{ malformed JSON"`). The function returns `true` and handles it correctly without error.
2. **Invalid Structure:** The lock file contains a valid JSON string but misses required properties or structure (`JSON.stringify({ pid: "not a number" })`). The function returns `true` and ignores it appropriately.

✨ **Result:** The improvement in test coverage
Test coverage is improved for the `sync-lock.ts` utility specifically focusing on the parse error edge cases. The changes help to ensure better resilience of `tryRemoveStaleLock` against corrupted lock files while confirming the file safely handles parsing problems.

---
*PR created automatically by Jules for task [18309908146626772327](https://jules.google.com/task/18309908146626772327) started by @catoncat*