### PR TITLE
🧹 [Refactor `ensureSchema` to reduce complexity]

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,16 @@
 import type { Db } from "./shared";
 
 export function ensureSchema(db: Db): void {
+  ensureSessionsTable(db);
+  ensureMessagesTable(db);
+  ensureMessagesFtsTable(db);
+  ensureSessionsFtsTable(db);
+  ensureCoverageTable(db);
+
+  dropLegacyTrigramTable(db);
+}
+
+function ensureSessionsTable(db: Db): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -30,6 +40,10 @@ export function ensureSchema(db: Db): void {
   ensureTextColumn(db, "sessions", "path_date");
   ensureTextColumn(db, "sessions", "source_root");
 
+  db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at DESC)");
+}
+
+function ensureMessagesTable(db: Db): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS messages (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -45,8 +59,9 @@ export function ensureSchema(db: Db): void {
   `);
 
   db.exec("CREATE INDEX IF NOT EXISTS idx_messages_session_seq ON messages(session_uuid, seq)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at DESC)");
+}
 
+function ensureMessagesFtsTable(db: Db): void {
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
       content_text,
@@ -57,11 +72,6 @@ export function ensureSchema(db: Db): void {
       tokenize='unicode61 remove_diacritics 1'
     )
   `);
-
-  ensureSessionsFtsTable(db);
-  ensureCoverageTable(db);
-
-  dropLegacyTrigramTable(db);
 }
 
 function ensureCoverageTable(db: Db): void {


### PR DESCRIPTION
🎯 **What:** The monolithic `ensureSchema` function in `src/db/schema.ts` was refactored into smaller functions, extracting the table creation and index initialization for `sessions`, `messages`, and `messages_fts` into `ensureSessionsTable`, `ensureMessagesTable`, and `ensureMessagesFtsTable` respectively.

💡 **Why:** Splitting this function up simplifies the schema code and reduces complexity in the main flow, making it significantly easier to maintain and understand. Grouping the column and index modifications inside each respective table's initialization function further organizes the domain logic.

✅ **Verification:** I confirmed that `npm run check` continues to compile without issues and that all vitest unit tests pass successfully, validating that the underlying schema generation behavior hasn't changed.

✨ **Result:** A much cleaner `ensureSchema` orchestrator that explicitly models the execution flow, improving code health without modifying application behavior.

---
*PR created automatically by Jules for task [15457652528117091962](https://jules.google.com/task/15457652528117091962) started by @catoncat*