### PR TITLE
🧪 [testing improvement] Add tests for CJK classification

### DIFF
--- a/src/query-cjk.test.ts
+++ b/src/query-cjk.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isCjkTerm } from "./query/cjk";
+
+describe("isCjkTerm", () => {
+  it("returns true for purely CJK strings", () => {
+    // Han script
+    expect(isCjkTerm("汉字")).toBe(true);
+    expect(isCjkTerm("漢字")).toBe(true);
+
+    // Hiragana
+    expect(isCjkTerm("ひらがな")).toBe(true);
+
+    // Katakana
+    expect(isCjkTerm("カタカナ")).toBe(true);
+
+    // Hangul
+    expect(isCjkTerm("한글")).toBe(true);
+
+    // Mixed CJK scripts
+    expect(isCjkTerm("漢字ひらがなカタカナ한글")).toBe(true);
+  });
+
+  it("returns false for non-CJK strings", () => {
+    expect(isCjkTerm("hello")).toBe(false);
+    expect(isCjkTerm("test")).toBe(false);
+    expect(isCjkTerm("123")).toBe(false);
+    expect(isCjkTerm("   ")).toBe(false);
+    expect(isCjkTerm("")).toBe(false); // empty string
+  });
+
+  it("returns false for mixed CJK and non-CJK strings", () => {
+    expect(isCjkTerm("hello漢字")).toBe(false);
+    expect(isCjkTerm("漢字123")).toBe(false);
+    expect(isCjkTerm("漢字 ")).toBe(false); // trailing space
+    expect(isCjkTerm(" 漢字")).toBe(false); // leading space
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `isCjkTerm` function in `src/query/cjk.ts` was missing tests. This function classifies tokens as purely CJK using a regex that checks for `Han`, `Hiragana`, `Katakana`, and `Hangul` scripts.

📊 **Coverage:** 
- Happy paths: Purely CJK strings including single scripts (e.g., Han only, Hiragana only) and mixed scripts.
- Edge cases: Empty strings.
- Error conditions: Non-CJK strings (Latin, numbers, spaces) and mixed strings containing both CJK and non-CJK characters.

✨ **Result:** Test coverage for `src/query/cjk.ts` is improved, ensuring the correctness and reliability of the `isCjkTerm` regex over time.

---
*PR created automatically by Jules for task [18309676045395427114](https://jules.google.com/task/18309676045395427114) started by @catoncat*