### PR TITLE
🧹 [code health improvement] Log `closeSync` failures explicitly in `readCwdMetadata`

### DIFF
--- a/src/source-inventory.ts
+++ b/src/source-inventory.ts
@@ -121,8 +121,8 @@ function readCwdMetadata(filePath: string): string {
     if (fd !== null) {
       try {
         closeSync(fd);
-      } catch {
-        // Ignore inventory-only close failures.
+      } catch (err) {
+        console.warn(`Failed to close file ${filePath} during inventory scan:`, err);
       }
     }
   }


### PR DESCRIPTION
🎯 **What:** Modified the `readCwdMetadata` function in `src/source-inventory.ts` to log an error when `closeSync` fails during inventory scanning.
💡 **Why:** Silently swallowing errors with an empty `catch` block makes it difficult to debug potential file handle leaks or permission issues. Logging the error explicitly with context (the `filePath`) improves observability and code maintainability.
✅ **Verification:** Verified the fix by running the full test suite (`npm run check` and `npx vitest run src/source-inventory.test.ts`), and confirming all 95 tests continue to pass correctly.
✨ **Result:** Improved debuggability and code health for `closeSync` failures without changing functionality.

---
*PR created automatically by Jules for task [15053687459403755733](https://jules.google.com/task/15053687459403755733) started by @catoncat*