### PR TITLE
🔒 Fix SQL Injection vulnerability in selectorWhereSql

### DIFF
--- a/src/db/sql.test.ts
+++ b/src/db/sql.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { selectorWhereSql } from "./sql";
+
+describe("selectorWhereSql", () => {
+  it("generates SQL conditions for valid aliases", () => {
+    const selector = { kind: "all" as const, root: "/test/root" };
+    const { conditions, params } = selectorWhereSql(selector, "s");
+    expect(conditions).toEqual(["(s.file_path = ? OR s.file_path LIKE ? ESCAPE '\\')"]);
+    expect(params).toEqual(["/test/root", "/test/root/%"]);
+  });
+
+  it("throws an error for invalid aliases to prevent SQL injection", () => {
+    const selector = { kind: "all" as const, root: "/test/root" };
+    expect(() => selectorWhereSql(selector, "s; DROP TABLE users;")).toThrow("Invalid table alias");
+    expect(() => selectorWhereSql(selector, "s JOIN m")).toThrow("Invalid table alias");
+    expect(() => selectorWhereSql(selector, "s.m")).toThrow("Invalid table alias");
+    expect(() => selectorWhereSql(selector, '"s"')).toThrow("Invalid table alias");
+    expect(() => selectorWhereSql(selector, "")).toThrow("Invalid table alias");
+  });
+});

--- a/src/db/sql.ts
+++ b/src/db/sql.ts
@@ -2,6 +2,7 @@ import type { Selector } from "../types";
 import type { Db, SqlParams } from "./shared";
 
 export function selectorWhereSql(selector: Selector, alias: string): { conditions: string[]; params: SqlParams } {
+  if (!/^[a-zA-Z0-9_]+$/.test(alias)) throw new Error("Invalid table alias");
   const conditions = [`(${alias}.file_path = ? OR ${alias}.file_path LIKE ? ESCAPE '\\')`];
   const params: SqlParams = [selector.root, `${escapeLike(selector.root)}/%`];
   if (selector.kind === "cwd" || selector.kind === "cwd_date_range") {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential SQL injection via the `alias` parameter in the `selectorWhereSql` function in `src/db/sql.ts`.

⚠️ **Risk:** If an untrusted string is passed as the `alias` parameter, it can alter the intended SQL query structure and result in arbitrary database command execution since it is concatenated directly into the query string.

🛡️ **Solution:** The fix adds a strict regex validation (`/^[a-zA-Z0-9_]+$/`) to the `alias` parameter at the beginning of `selectorWhereSql`, ensuring only standard safe table aliases can be used and throwing an error otherwise. Validating this fast path mitigates injection without requiring complex refactoring of the parameterized query structure. Unit tests were also added in `src/db/sql.test.ts` to verify the security check prevents exploits.

---
*PR created automatically by Jules for task [8115798016798854358](https://jules.google.com/task/8115798016798854358) started by @catoncat*