### PR TITLE
fix(index): 加固同步与索引一致性

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -7,6 +7,7 @@ export { getStatsCounts, getTopCwds } from "./db/stats-store";
 export {
   coverageEntriesForSession,
   coverageStatusForSelector,
+  cleanupMismatchedMessagesForSelector,
   countSessionsForSelector,
   deleteSessionsForSelectorExceptFilePaths,
   listCoverageRecords,

--- a/src/db/coverage-store.test.ts
+++ b/src/db/coverage-store.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { INDEX_VERSION } from "../env";
+import { cleanupMismatchedMessagesForSelector, deleteSessionsForSelectorExceptFilePaths } from "./coverage-store";
+import { openReadDb, openWriteDb, replaceSession } from "../db";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("deleteSessionsForSelectorExceptFilePaths", () => {
+  test("does not bind retained file paths into a huge NOT IN clause", () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-coverage-retained-"));
+    tempDirs.push(base);
+    const dbPath = join(base, "index.sqlite");
+    const root = join(base, "sessions");
+    const stalePath = join(root, "stale.jsonl");
+    const db = openWriteDb(dbPath);
+
+    replaceSession(
+      db,
+      {
+        sessionUuid: "11111111-1111-4111-8111-111111111111",
+        filePath: stalePath,
+        title: "stale",
+        summaryText: "stale",
+        compactText: "",
+        reasoningSummaryText: "",
+        cwd: "/tmp/retained",
+        model: "gpt-5.4",
+        startedAt: "2026-04-22T00:00:00.000Z",
+        endedAt: "2026-04-22T00:00:00.000Z",
+        messages: [],
+      },
+      1,
+      1,
+      INDEX_VERSION,
+      "2026-04-22",
+      root,
+    );
+
+    const retained = new Set<string>();
+    for (let index = 0; index < 50_000; index += 1) {
+      retained.add(join(root, `retained-${index}.jsonl`));
+    }
+
+    const removed = deleteSessionsForSelectorExceptFilePaths(db, { kind: "all", root }, retained);
+    db.close();
+
+    const readDb = openReadDb(dbPath);
+    const count = readDb.prepare("SELECT COUNT(*) AS count FROM sessions").get() as { count: number };
+    readDb.close();
+
+    expect(removed).toBe(1);
+    expect(count.count).toBe(0);
+  });
+});
+
+describe("cleanupMismatchedMessagesForSelector", () => {
+  test("removes legacy message rows whose session_uuid no longer matches the owning session row", () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-coverage-mismatched-messages-"));
+    tempDirs.push(base);
+    const dbPath = join(base, "index.sqlite");
+    const root = join(base, "sessions");
+    const filePath = join(root, "current.jsonl");
+    const db = openWriteDb(dbPath);
+
+    replaceSession(
+      db,
+      {
+        sessionUuid: "22222222-2222-4222-8222-222222222222",
+        filePath,
+        title: "current",
+        summaryText: "current",
+        compactText: "",
+        reasoningSummaryText: "",
+        cwd: "/tmp/mismatch",
+        model: "gpt-5.4",
+        startedAt: "2026-04-22T00:00:00.000Z",
+        endedAt: "2026-04-22T00:00:00.000Z",
+        messages: [
+          {
+            role: "user",
+            contentText: "current message",
+            timestamp: "2026-04-22T00:00:00.000Z",
+            seq: 0,
+            sourceKind: "event_msg",
+          },
+        ],
+      },
+      1,
+      1,
+      INDEX_VERSION,
+      "2026-04-22",
+      root,
+    );
+    const session = db.prepare("SELECT id FROM sessions WHERE session_uuid = ?").get("22222222-2222-4222-8222-222222222222") as { id: number };
+    const inserted = db.prepare(`
+      INSERT INTO messages (session_id, session_uuid, seq, role, content_text, timestamp, source_kind)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      session.id,
+      "11111111-1111-4111-8111-111111111111",
+      1,
+      "user",
+      "legacy orphan message",
+      "2026-04-22T00:00:01.000Z",
+      "event_msg",
+    );
+    db.prepare("INSERT INTO messages_fts(rowid, content_text, session_uuid, seq, role, timestamp) VALUES (?, ?, ?, ?, ?, ?)").run(
+      Number(inserted.lastInsertRowid),
+      "legacy orphan message",
+      "11111111-1111-4111-8111-111111111111",
+      1,
+      "user",
+      "2026-04-22T00:00:01.000Z",
+    );
+
+    const removed = cleanupMismatchedMessagesForSelector(db, { kind: "all", root });
+    db.close();
+
+    const readDb = openReadDb(dbPath);
+    const messages = readDb.prepare("SELECT session_uuid AS sessionUuid, content_text AS contentText FROM messages ORDER BY seq").all() as Array<{
+      sessionUuid: string;
+      contentText: string;
+    }>;
+    const ftsRows = readDb.prepare("SELECT session_uuid AS sessionUuid FROM messages_fts").all() as Array<{ sessionUuid: string }>;
+    readDb.close();
+
+    expect(removed).toBe(1);
+    expect(messages).toEqual([{ sessionUuid: "22222222-2222-4222-8222-222222222222", contentText: "current message" }]);
+    expect(ftsRows).toEqual([{ sessionUuid: "22222222-2222-4222-8222-222222222222" }]);
+  });
+});

--- a/src/db/coverage-store.ts
+++ b/src/db/coverage-store.ts
@@ -86,24 +86,46 @@ export function deleteSessionsForSelectorExceptFilePaths(
   retainedFilePaths: Set<string>,
 ): number {
   const where = selectorWhereSql(selector, "sessions");
-  const params = [...where.params];
-  const retained = [...retainedFilePaths];
-  const retainedClause = retained.length > 0
-    ? ` AND sessions.file_path NOT IN (${retained.map(() => "?").join(", ")})`
-    : "";
-  params.push(...retained);
   const rows = db
-    .prepare(`
-      SELECT session_uuid AS sessionUuid
+    .prepare<typeof where.params, { sessionUuid: string; filePath: string }>(`
+      SELECT session_uuid AS sessionUuid, file_path AS filePath
       FROM sessions
-      WHERE ${where.conditions.join(" AND ")}${retainedClause}
+      WHERE ${where.conditions.join(" AND ")}
     `)
-    .all(...params) as Array<{ sessionUuid: string }>;
+    .all(...where.params) as Array<{ sessionUuid: string; filePath: string }>;
 
+  let removed = 0;
   for (const row of rows) {
+    if (retainedFilePaths.has(row.filePath)) continue;
     deleteSessionByUuid(db, row.sessionUuid);
+    removed += 1;
   }
-  return rows.length;
+  return removed;
+}
+
+export function cleanupMismatchedMessagesForSelector(db: Db, selector: Selector): number {
+  const where = selectorWhereSql(selector, "s");
+  const conditions = [...where.conditions, "m.session_uuid != s.session_uuid"];
+  const predicate = conditions.join(" AND ");
+  db.prepare<typeof where.params>(`
+    DELETE FROM messages_fts
+    WHERE rowid IN (
+      SELECT m.id
+      FROM messages m
+      JOIN sessions s ON s.id = m.session_id
+      WHERE ${predicate}
+    )
+  `).run(...where.params);
+  const result = db.prepare<typeof where.params>(`
+    DELETE FROM messages
+    WHERE id IN (
+      SELECT m.id
+      FROM messages m
+      JOIN sessions s ON s.id = m.session_id
+      WHERE ${predicate}
+    )
+  `).run(...where.params);
+  return Number(result.changes);
 }
 
 export function coverageEntriesForSession(db: Db, session: SessionRecord): CoverageRecord[] {

--- a/src/db/session-store.test.ts
+++ b/src/db/session-store.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { INDEX_VERSION } from "../env";
+import { findSessions } from "../query";
+import { openReadDb, openWriteDb, replaceSession } from "../db";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("replaceSession", () => {
+  test("replacing the same file with a new session uuid removes old messages and FTS rows", () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-session-store-uuid-change-"));
+    tempDirs.push(base);
+    const dbPath = join(base, "index.sqlite");
+    const filePath = join(base, "sessions", "rollout.jsonl");
+    const db = openWriteDb(dbPath);
+
+    replaceSession(
+      db,
+      sessionFixture({
+        sessionUuid: "11111111-1111-4111-8111-111111111111",
+        filePath,
+        message: "old unique needle",
+      }),
+      1,
+      100,
+      INDEX_VERSION,
+      "2026-04-22",
+      join(base, "sessions"),
+    );
+    replaceSession(
+      db,
+      sessionFixture({
+        sessionUuid: "22222222-2222-4222-8222-222222222222",
+        filePath,
+        message: "new unique needle",
+      }),
+      2,
+      100,
+      INDEX_VERSION,
+      "2026-04-22",
+      join(base, "sessions"),
+    );
+    db.close();
+
+    const readDb = openReadDb(dbPath);
+    const messageRows = readDb.prepare("SELECT session_uuid AS sessionUuid, content_text AS contentText FROM messages").all() as Array<{
+      sessionUuid: string;
+      contentText: string;
+    }>;
+    const ftsCount = readDb.prepare("SELECT COUNT(*) AS count FROM messages_fts").get() as { count: number };
+    readDb.close();
+
+    expect(messageRows).toEqual([
+      {
+        sessionUuid: "22222222-2222-4222-8222-222222222222",
+        contentText: "new unique needle",
+      },
+    ]);
+    expect(ftsCount.count).toBe(1);
+    expect(findSessions(dbPath, "old unique needle", 5).results).toEqual([]);
+    expect(findSessions(dbPath, "new unique needle", 5).results[0]?.sessionUuid).toBe("22222222-2222-4222-8222-222222222222");
+  });
+});
+
+function sessionFixture(options: { sessionUuid: string; filePath: string; message: string }) {
+  return {
+    sessionUuid: options.sessionUuid,
+    filePath: options.filePath,
+    title: options.message,
+    summaryText: options.message,
+    compactText: "",
+    reasoningSummaryText: "",
+    cwd: "/tmp/uuid-change",
+    model: "gpt-5.4",
+    startedAt: "2026-04-22T00:00:00.000Z",
+    endedAt: "2026-04-22T00:00:00.000Z",
+    messages: [
+      {
+        role: "user" as const,
+        contentText: options.message,
+        timestamp: "2026-04-22T00:00:00.000Z",
+        seq: 0,
+        sourceKind: "event_msg" as const,
+      },
+    ],
+  };
+}

--- a/src/db/session-store.ts
+++ b/src/db/session-store.ts
@@ -79,8 +79,8 @@ export function replaceSession(
 ): void {
   const tx = db.transaction(() => {
     const existing = db
-      .prepare<[string, string], { id: number }>("SELECT id FROM sessions WHERE session_uuid = ? OR file_path = ? LIMIT 1")
-      .get(session.sessionUuid, session.filePath) as { id: number } | undefined;
+      .prepare<[string, string], { id: number; sessionUuid: string }>("SELECT id, session_uuid AS sessionUuid FROM sessions WHERE session_uuid = ? OR file_path = ? LIMIT 1")
+      .get(session.sessionUuid, session.filePath) as { id: number; sessionUuid: string } | undefined;
 
     if (existing) {
       db.prepare(
@@ -143,8 +143,13 @@ export function replaceSession(
       .prepare<[string], { id: number }>("SELECT id FROM sessions WHERE session_uuid = ? LIMIT 1")
       .get(session.sessionUuid) as { id: number };
 
+    db.prepare("DELETE FROM messages_fts WHERE rowid IN (SELECT id FROM messages WHERE session_id = ?)").run(sessionRow.id);
+    db.prepare("DELETE FROM messages WHERE session_id = ?").run(sessionRow.id);
+    if (existing && existing.sessionUuid !== session.sessionUuid) {
+      db.prepare("DELETE FROM messages_fts WHERE session_uuid = ?").run(existing.sessionUuid);
+      db.prepare("DELETE FROM sessions_fts WHERE session_uuid = ?").run(existing.sessionUuid);
+    }
     db.prepare("DELETE FROM messages_fts WHERE session_uuid = ?").run(session.sessionUuid);
-    db.prepare("DELETE FROM messages WHERE session_uuid = ?").run(session.sessionUuid);
     db.prepare("DELETE FROM sessions_fts WHERE rowid = ? OR session_uuid = ?").run(sessionRow.id, session.sessionUuid);
 
     db.prepare(

--- a/src/db/sql.test.ts
+++ b/src/db/sql.test.ts
@@ -9,11 +9,22 @@ describe("selectorWhereSql", () => {
     expect(params).toEqual(["/test/root", "/test/root/%"]);
   });
 
+  it("escapes selector roots while still allowing underscore aliases", () => {
+    const selector = { kind: "cwd" as const, root: "/test/r%ot", cwd: "/tmp/project" };
+    const { conditions, params } = selectorWhereSql(selector, "s_1");
+    expect(conditions).toEqual([
+      "(s_1.file_path = ? OR s_1.file_path LIKE ? ESCAPE '\\')",
+      "s_1.cwd = ?",
+    ]);
+    expect(params).toEqual(["/test/r%ot", "/test/r\\%ot/%", "/tmp/project"]);
+  });
+
   it("throws an error for invalid aliases to prevent SQL injection", () => {
     const selector = { kind: "all" as const, root: "/test/root" };
     expect(() => selectorWhereSql(selector, "s; DROP TABLE users;")).toThrow("Invalid table alias");
     expect(() => selectorWhereSql(selector, "s JOIN m")).toThrow("Invalid table alias");
     expect(() => selectorWhereSql(selector, "s.m")).toThrow("Invalid table alias");
+    expect(() => selectorWhereSql(selector, "1s")).toThrow("Invalid table alias");
     expect(() => selectorWhereSql(selector, '"s"')).toThrow("Invalid table alias");
     expect(() => selectorWhereSql(selector, "")).toThrow("Invalid table alias");
   });

--- a/src/db/sql.ts
+++ b/src/db/sql.ts
@@ -2,7 +2,9 @@ import type { Selector } from "../types";
 import type { Db, SqlParams } from "./shared";
 
 export function selectorWhereSql(selector: Selector, alias: string): { conditions: string[]; params: SqlParams } {
-  if (!/^[a-zA-Z0-9_]+$/.test(alias)) throw new Error("Invalid table alias");
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias)) {
+    throw new Error("Invalid table alias");
+  }
   const conditions = [`(${alias}.file_path = ? OR ${alias}.file_path LIKE ? ESCAPE '\\')`];
   const params: SqlParams = [selector.root, `${escapeLike(selector.root)}/%`];
   if (selector.kind === "cwd" || selector.kind === "cwd_date_range") {

--- a/src/indexer.test.ts
+++ b/src/indexer.test.ts
@@ -157,6 +157,76 @@ describe("syncSessions", () => {
     ]);
   });
 
+  test("strict sync refuses an unavailable source root instead of deleting indexed rows", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-indexer-missing-root-"));
+    tempDirs.push(base);
+    const root = join(base, "sessions");
+    const day = join(root, "2026", "04", "22");
+    mkdirSync(day, { recursive: true });
+
+    writeFileSync(
+      join(day, "rollout-2026-04-22T12-00-00-44444444-4444-4444-8444-444444444444.jsonl"),
+      [
+        line("session_meta", { id: "44444444-4444-4444-8444-444444444444", cwd: "/tmp/missing-root" }),
+        line("event_msg", { type: "user_message", message: "keep this indexed row" }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const selector = { kind: "all" as const, root };
+    await syncSessions({ dbPath, selector });
+
+    rmSync(root, { recursive: true, force: true });
+    const failure = await syncSessions({ dbPath, selector }).catch((error) => error);
+
+    expect(failure).toBeInstanceOf(SyncError);
+    expect(failure.summary.errors).toBe(1);
+    expect(failure.summary.coverage.written).toBe(false);
+    expect(failure.summary.coverage.reason).toBe("source_unavailable");
+    expect(failure.summary.errorDetails[0]?.filePath).toBe(root);
+
+    const db = openReadDb(dbPath);
+    const sessions = db.prepare("SELECT session_uuid AS sessionUuid FROM sessions").all() as Array<{ sessionUuid: string }>;
+    const coverage = db.prepare("SELECT source_file_count AS sourceFileCount FROM coverage").get() as { sourceFileCount: number };
+    db.close();
+
+    expect(sessions).toEqual([{ sessionUuid: "44444444-4444-4444-8444-444444444444" }]);
+    expect(coverage.sourceFileCount).toBe(1);
+  });
+
+  test("strict sync does not create a new index database when the source root is unavailable", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-indexer-missing-root-new-db-"));
+    tempDirs.push(base);
+    const root = join(base, "missing-sessions");
+    const dbPath = join(base, "index.sqlite");
+
+    const failure = await syncSessions({
+      dbPath,
+      selector: { kind: "all", root },
+    }).catch((error) => error);
+
+    expect(failure).toBeInstanceOf(SyncError);
+    expect(failure.summary.coverage.reason).toBe("source_unavailable");
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  test("cwd selector refuses unreadable cwd metadata instead of writing false coverage", async () => {
+    const { dbPath, sessionsRoot, badFilePath } = createFixture();
+
+    const failure = await syncSessions({
+      dbPath,
+      selector: { kind: "cwd", root: sessionsRoot, cwd: "/tmp/bad" },
+    }).catch((error) => error);
+
+    expect(failure).toBeInstanceOf(SyncError);
+    expect(failure.summary.errors).toBe(1);
+    expect(failure.summary.coverage.written).toBe(false);
+    expect(failure.summary.coverage.reason).toBe("source_unavailable");
+    expect(failure.summary.errorDetails[0]?.filePath).toBe(badFilePath);
+
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
   test("strict sync rebuilds legacy rows missing path_date before date-range coverage", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-indexer-legacy-path-date-"));
     tempDirs.push(base);

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_DB_PATH, INDEX_VERSION, ensureDataDir, resolveCodexDir } from "./env";
 import {
+  cleanupMismatchedMessagesForSelector,
   countSessionsForSelector,
   deleteSessionsForSelectorExceptFilePaths,
   deleteSessionByFilePath,
@@ -11,7 +12,7 @@ import {
 } from "./db";
 import { parseCodexSession } from "./parser";
 import { canonicalizeSelector } from "./selector";
-import { collectSourceSnapshot } from "./source-inventory";
+import { SourceInventoryError, collectSourceSnapshot } from "./source-inventory";
 import { withSyncLock } from "./sync-lock";
 import type { CoverageWriteSummary, ParsedSession, Selector, SyncErrorDetail, SyncSummary } from "./types";
 
@@ -52,8 +53,14 @@ export async function syncSessions(options: SyncOptions = {}): Promise<SyncSumma
   const dbPath = options.dbPath ?? DEFAULT_DB_PATH;
   const selector = canonicalizeSelector(options.selector ?? { kind: "all", root: resolveCodexDir(options.rootDir) });
   return withSyncLock(dbPath, async () => {
+    let sourceSnapshot;
+    try {
+      sourceSnapshot = await collectSourceSnapshot(selector, { strict: true });
+    } catch (error) {
+      const summary = sourceUnavailableSummary(selector, error);
+      throw new SyncError(summary);
+    }
     const db = openWriteDb(dbPath);
-    const sourceSnapshot = await collectSourceSnapshot(selector);
     const operations: SyncOperation[] = [];
     const unchangedFilePaths = new Set<string>();
 
@@ -84,7 +91,13 @@ export async function syncSessions(options: SyncOptions = {}): Promise<SyncSumma
       }
 
       if (!options.bestEffort) {
-        const afterSnapshot = await collectSourceSnapshot(selector);
+        let afterSnapshot;
+        try {
+          afterSnapshot = await collectSourceSnapshot(selector, { strict: true });
+        } catch (error) {
+          recordSyncError(summary, sourceErrorPath(selector, error), error);
+          throw new SyncError(summary);
+        }
         if (afterSnapshot.fingerprint !== sourceSnapshot.fingerprint) {
           recordSyncError(summary, "(selector)", new Error("source changed during strict sync"));
           throw new SyncError(summary);
@@ -209,6 +222,7 @@ function applyOperations(
       currentFilePath = operation.filePath;
       applyOperation(db, operation, selector.root);
     }
+    cleanupMismatchedMessagesForSelector(db, selector);
     summary.removed += deleteSessionsForSelectorExceptFilePaths(db, selector, retainedFilePaths);
     const indexedSessionCount = countSessionsForSelector(db, selector);
     const record = replaceCoverage(
@@ -319,4 +333,25 @@ function skippedCoverage(
     indexedSessionCount: 0,
     reason,
   };
+}
+
+function sourceUnavailableSummary(selector: Selector, error: unknown): SyncSummary {
+  const summary: SyncSummary = {
+    scanned: 0,
+    added: 0,
+    updated: 0,
+    skipped: 0,
+    filtered: 0,
+    removed: 0,
+    errors: 0,
+    errorDetails: [],
+    selector,
+    coverage: skippedCoverage(selector, "", 0, "source_unavailable"),
+  };
+  recordSyncError(summary, sourceErrorPath(selector, error), error);
+  return summary;
+}
+
+function sourceErrorPath(selector: Selector, error: unknown): string {
+  return error instanceof SourceInventoryError ? error.path : selector.root;
 }

--- a/src/source-inventory.ts
+++ b/src/source-inventory.ts
@@ -13,6 +13,21 @@ import type {
 
 const CWD_SCAN_BYTES = 64 * 1024;
 
+interface CollectSourceFilesOptions {
+  strict?: boolean;
+  requireCwdMetadata?: boolean;
+}
+
+export class SourceInventoryError extends Error {
+  readonly path: string;
+
+  constructor(path: string, operation: string, cause: unknown) {
+    super(`${operation} failed for ${path}: ${describeError(cause)}`);
+    this.name = "SourceInventoryError";
+    this.path = path;
+  }
+}
+
 export async function collectSourceInventory(root: string): Promise<SourceInventory> {
   const resolvedRoot = resolve(root);
   const files = await collectSourceFiles(resolvedRoot);
@@ -24,9 +39,12 @@ export async function collectSourceInventory(root: string): Promise<SourceInvent
   };
 }
 
-export async function collectSourceSnapshot(selector: Selector): Promise<SourceSnapshot> {
+export async function collectSourceSnapshot(selector: Selector, options: CollectSourceFilesOptions = {}): Promise<SourceSnapshot> {
   const canonical = canonicalizeSelector(selector);
-  const allFiles = await collectSourceFiles(canonical.root);
+  const allFiles = await collectSourceFiles(canonical.root, {
+    ...options,
+    requireCwdMetadata: options.requireCwdMetadata ?? (canonical.kind === "cwd" || canonical.kind === "cwd_date_range"),
+  });
   const files = allFiles.filter((file) => selectorContainsFile(canonical, file));
   return {
     selector: canonical,
@@ -36,9 +54,9 @@ export async function collectSourceSnapshot(selector: Selector): Promise<SourceS
   };
 }
 
-export async function collectSourceFiles(root: string): Promise<SourceFileMeta[]> {
+export async function collectSourceFiles(root: string, options: CollectSourceFilesOptions = {}): Promise<SourceFileMeta[]> {
   const files: SourceFileMeta[] = [];
-  await walkAsync(resolve(root), files);
+  await walkAsync(resolve(root), files, options);
   files.sort((a, b) => a.filePath.localeCompare(b.filePath));
   return files;
 }
@@ -51,11 +69,12 @@ export function extractPathDate(filePath: string): string | null {
   return null;
 }
 
-async function walkAsync(currentDir: string, files: SourceFileMeta[]): Promise<void> {
+async function walkAsync(currentDir: string, files: SourceFileMeta[], options: CollectSourceFilesOptions): Promise<void> {
   let dirHandle;
   try {
     dirHandle = await opendir(currentDir);
-  } catch {
+  } catch (error) {
+    if (options.strict) throw new SourceInventoryError(currentDir, "read directory", error);
     return;
   }
 
@@ -66,14 +85,14 @@ async function walkAsync(currentDir: string, files: SourceFileMeta[]): Promise<v
   for await (const entry of dirHandle) {
     const fullPath = `${currentDir}/${entry.name}`;
     if (entry.isDirectory()) {
-      await walkAsync(fullPath, files);
+      await walkAsync(fullPath, files, options);
       continue;
     }
     if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
 
     try {
       const stats = await stat(fullPath);
-      const cwd = await readCwdMetadataAsync(fullPath);
+      const cwd = await readCwdMetadataAsync(fullPath, options);
       files.push({
         filePath: fullPath,
         pathDate: extractPathDate(fullPath),
@@ -81,13 +100,14 @@ async function walkAsync(currentDir: string, files: SourceFileMeta[]): Promise<v
         mtimeMs: stats.mtimeMs,
         size: stats.size,
       });
-    } catch {
-      // Ignore
+    } catch (error) {
+      if (options.strict) throw error instanceof SourceInventoryError ? error : new SourceInventoryError(fullPath, "stat file", error);
+      continue;
     }
   }
 }
 
-async function readCwdMetadataAsync(filePath: string): Promise<string> {
+async function readCwdMetadataAsync(filePath: string, options: CollectSourceFilesOptions): Promise<string> {
   let fh = null;
   try {
     fh = await open(filePath, "r");
@@ -120,7 +140,8 @@ async function readCwdMetadataAsync(filePath: string): Promise<string> {
         return payload.cwd;
       }
     }
-  } catch {
+  } catch (error) {
+    if (options.strict && options.requireCwdMetadata) throw new SourceInventoryError(filePath, "read cwd metadata", error);
     return "";
   } finally {
     if (fh !== null) {
@@ -187,4 +208,9 @@ function fingerprintFiles(root: string, files: SourceFileMeta[]): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }

--- a/src/sync-lock.test.ts
+++ b/src/sync-lock.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { tryRemoveStaleLock } from "./sync-lock";
+import { readLockInfo, tryRemoveStaleLock } from "./sync-lock";
 
 const tempDirs: string[] = [];
 
@@ -141,6 +141,28 @@ describe("tryRemoveStaleLock", () => {
 
       expect(removed).toBe(true);
       expect(existsSync(lockPath)).toBe(false);
+    });
+
+    test("recovers stale directory locks whose JSON info file was partially written", () => {
+      const lockPath = makeLockPath();
+      const expected = { pid: 999_999, createdAt: "2026-04-27T00:00:00.000Z" };
+
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, getInfoFilename(expected.pid, expected.createdAt)), "{ malformed JSON");
+
+      const parsed = readLockInfo(lockPath);
+      expect(parsed).toEqual(expected);
+      expect(parsed && parsed !== "empty" && parsed !== "legacy" && tryRemoveStaleLock(lockPath, parsed)).toBe(true);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    test("ignores malformed JSON info files with invalid filename timestamps", () => {
+      const lockPath = makeLockPath();
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, "999999-999999999999999999999999.json"), "{ malformed JSON");
+
+      expect(() => readLockInfo(lockPath)).not.toThrow();
+      expect(readLockInfo(lockPath)).toBe("empty");
     });
   });
 });

--- a/src/sync-lock.ts
+++ b/src/sync-lock.ts
@@ -179,7 +179,8 @@ export function readLockInfo(lockPath: string): ParsedLockInfo | "empty" | "lega
           return { pid: parsed.pid, createdAt: parsed.createdAt };
         }
       } catch {
-        // Ignore read errors for individual files
+        const filenameInfo = lockInfoFromFilename(file);
+        if (filenameInfo) return filenameInfo;
       }
     }
   }
@@ -189,6 +190,18 @@ export function readLockInfo(lockPath: string): ParsedLockInfo | "empty" | "lega
 
 function getInfoFilename(info: SyncLockInfo): string {
   return `${info.pid}-${new Date(info.createdAt).getTime()}.json`;
+}
+
+function lockInfoFromFilename(file: string): SyncLockInfo | null {
+  const match = file.match(/^(\d+)-(\d+)\.json$/);
+  if (!match) return null;
+  const pid = Number(match[1]);
+  const timestamp = Number(match[2]);
+  if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(timestamp)) return null;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return null;
+  const createdAt = date.toISOString();
+  return { pid, createdAt };
 }
 
 function isProcessAlive(pid: number): boolean {


### PR DESCRIPTION
<!-- mainline:pr-description:start -->
## Mainline Intent

**Intent:** `int_204ec808`
**Status:** `proposed`
**Title:** 加固 cxs 同步与索引一致性

### What changed

审计并修复 cxs strict sync、coverage 写入、session 替换、SQL helper 与 sync lock 的可复现一致性/安全缺陷：source root 不可用时不再创建空库或写空 coverage，cwd selector 遇到不可读 cwd metadata 时失败，旧 file_path 换 session_uuid 时清理旧 messages/FTS，strict sync 会清理历史 session_uuid 不匹配的 message rows，selector 删除不再构造巨大 NOT IN 参数，SQL alias 校验更严格，malformed directory lock 可以从文件名恢复 stale owner。

### Why

用户要求不要停在主观信心，而是持续找出可能漏洞并修到可验证收敛；这些缺陷都会让 cxs 在 source 不可用、selector 同步、历史索引漂移或锁损坏时产生 false coverage、旧内容继续可检索、SQLite 参数上限失败或 stale lock 阻塞。

### Decisions

- **source unavailable semantics:** strict sync 在 collectSourceSnapshot 失败时直接返回 source_unavailable 的 SyncError，且在打开 write DB 前失败。 (source root 不可读/不存在不是“空源”，不能删除旧索引、写空 coverage 或创建新空数据库。)
- **cwd selector metadata requirement:** cwd/cwd_date_range selector 的 source snapshot 要求 cwd metadata 可读。 (无法读取 cwd metadata 时不能证明文件是否属于该 selector，保守失败比静默漏选后写 complete coverage 更安全。)
- **session replacement cleanup:** replaceSession 同时按 session_id 和旧/新 session_uuid 清理 messages_fts、messages、sessions_fts。 (同一个 file_path 的 session_uuid 改变时，旧实现只按新 uuid 清理会留下旧 message/FTS 行，导致旧内容继续被 find 命中。)
- **coverage stale deletion scale:** selector 删除旧 rows 改成先查候选 rows，再用 JS Set 过滤 retained file_path。 (避免 retained set 很大时拼出超过 SQLite variable limit 的 NOT IN 占位符列表，同时保持按 selector 删除旧索引的语义。)
- **legacy mismatch cleanup:** strict apply 阶段加入 cleanupMismatchedMessagesForSelector。 (它能在下一次 strict selector sync 中清理旧版本遗留的 messages.session_uuid 与 sessions.session_uuid 不一致的 rows，而无需引入一次性迁移。)
- **malformed lock recovery:** sync lock malformed JSON directory info 从受限 filename 格式恢复 pid/createdAt。 (部分写入的 info JSON 仍可安全识别 stale owner；无效或超大 timestamp filename 则按 empty 忽略，避免抛异常。)

**Subsystems:** indexer, source-inventory, db-session-store, db-coverage-store, db-sql-helper, sync-lock, tests
<!-- mainline:pr-description:end -->

