### PR TITLE
🔒 Fix SQL injection vulnerability in `ensureTextColumn` pragma queries

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -122,9 +122,11 @@ function ensureSessionsFtsTable(db: Db): void {
 
 function ensureTextColumn(db: Db, tableName: string, columnName: string): void {
   const columns = db
-    .prepare(`PRAGMA table_info(${tableName})`)
-    .all() as Array<{ name?: string }>;
+    .prepare("SELECT name FROM pragma_table_info(?)")
+    .all(tableName) as Array<{ name?: string }>;
 
   if (columns.some((column) => column.name === columnName)) return;
-  db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} TEXT NOT NULL DEFAULT ''`);
+
+  const quoteId = (id: string) => `"${id.replace(/"/g, '""')}"`;
+  db.exec(`ALTER TABLE ${quoteId(tableName)} ADD COLUMN ${quoteId(columnName)} TEXT NOT NULL DEFAULT ''`);
 }


### PR DESCRIPTION
🎯 **What:** 
Fixed two SQL injection vulnerabilities in `src/db/schema.ts` within the `ensureTextColumn` function. The first issue was an unparameterized `PRAGMA table_info` query. The second was the unescaped concatenation of `tableName` and `columnName` in an `ALTER TABLE` DDL command.

⚠️ **Risk:** 
If an attacker could control the `tableName` or `columnName` arguments passed to `ensureTextColumn`, they could inject malicious SQL commands. This could lead to arbitrary schema modification, data exfiltration, or complete database compromise.

🛡️ **Solution:** 
- Replaced the direct `PRAGMA` call with `SELECT name FROM pragma_table_info(?)`, which is the table-valued function equivalent in SQLite that safely supports bound parameters.
- Implemented a small inline helper `quoteId` to safely escape double quotes (`""`) and wrap the identifiers in double quotes before using them in the `ALTER TABLE` statement.

---
*PR created automatically by Jules for task [15851831852185133113](https://jules.google.com/task/15851831852185133113) started by @catoncat*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQL injection in `ensureTextColumn` by parameterizing the table info query and safely quoting identifiers in `ALTER TABLE`. Prevents arbitrary schema changes if `tableName` or `columnName` are user-controlled.

- **Bug Fixes**
  - Replaced `PRAGMA table_info(${tableName})` with `SELECT name FROM pragma_table_info(?)` using a bound parameter.
  - Added `quoteId` to escape and quote identifiers in `ALTER TABLE ... ADD COLUMN ... TEXT NOT NULL DEFAULT ''`.

<sup>Written for commit 928cb026a4c922018046ebc63556d54a2da4eade. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

