### PR TITLE
fix(cli): 简化 selector root 使用

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ cxs status --json
 Check coverage for a project:
 
 ```bash
-cxs status --selector '{"kind":"cwd","root":"/Users/you/.codex/sessions","cwd":"/Users/you/work/project"}' --json
+cxs status --cwd /Users/you/work/project --json
 ```
 
 If `requestedCoverage.recommendedAction` is `"sync"`, build or refresh coverage:
 
 ```bash
-cxs sync --selector '{"kind":"cwd","root":"/Users/you/.codex/sessions","cwd":"/Users/you/work/project"}'
+cxs sync --cwd /Users/you/work/project
 ```
 
 Replace the example paths with your own absolute paths.
@@ -82,8 +82,8 @@ cxs read-page <sessionUuid> --offset 0 --limit 20
 You can run the same flow without global installation:
 
 ```bash
-npx @act0r/cxs@latest sync --selector '{"kind":"all","root":"/Users/you/.codex/sessions"}'
-npx @act0r/cxs@latest find "health check"
+npx @act0r/cxs@latest sync --root /Users/you/.codex/sessions
+npx @act0r/cxs@latest find "health check" --root /Users/you/.codex/sessions
 ```
 
 ## Commands
@@ -91,8 +91,8 @@ npx @act0r/cxs@latest find "health check"
 | Command | Purpose |
 | --- | --- |
 | `cxs status` | Show execution context, source inventory, index state, and coverage. `--selector` checks whether a target range is fresh. Does not write the index. |
-| `cxs sync --selector <json>` | Scan selected Codex sessions and update the SQLite index. This is the only write command. |
-| `cxs find <query>` | Search indexed sessions and return ranked session candidates with minimal snippets. Use `--sort ended` for "latest + keyword" queries. |
+| `cxs sync --root <dir>\|--cwd <path>\|--selector <json>` | Scan selected Codex sessions and update the SQLite index. This is the only write command. |
+| `cxs find <query>` | Search indexed sessions and return ranked session candidates with minimal snippets. Use `--root`, `--cwd`, and `--sort ended` for scoped "latest + keyword" queries. |
 | `cxs read-range <sessionUuid>` | Read a small message window around a matched sequence or in-session query. |
 | `cxs read-page <sessionUuid>` | Read a session page by offset and limit. |
 | `cxs list` | List indexed sessions without full-text search. |
@@ -103,8 +103,19 @@ cleanly if the index has not been created yet.
 
 ## Selectors
 
-`sync` requires an explicit selector. Query commands can also accept selectors to
-constrain already-indexed results.
+`sync` requires an explicit scope, but it no longer requires handwritten
+`root` inside selector JSON. Prefer these CLI shortcuts:
+
+```bash
+cxs sync --root /Users/you/.codex/sessions
+cxs sync --cwd /Users/you/work/project
+cxs find "health check" --cwd /Users/you/work/project --sort ended
+cxs list --root /Users/you/.codex/sessions --sort ended -n 10
+```
+
+Use full selector JSON for date ranges or advanced scopes. If you pass
+`--root`, the selector JSON may omit `root`; without `--root`, cxs uses the
+default Codex sessions root.
 
 ```text
 {"kind":"all","root":"/Users/you/.codex/sessions"}
@@ -117,12 +128,13 @@ Example list query scoped to one project:
 
 ```bash
 cxs list --selector '{"kind":"cwd","root":"/Users/you/.codex/sessions","cwd":"/Users/you/work/project"}' --sort ended -n 10
+cxs list --selector '{"kind":"cwd","cwd":"/Users/you/work/project"}' --sort ended -n 10
 ```
 
 Example latest keyword query, excluding the current self-hit:
 
 ```bash
-cxs find "xsearch" --selector '{"kind":"cwd","root":"/Users/you/.codex/sessions","cwd":"/Users/you/work/project"}' --sort ended --exclude-session <current_session_uuid> -n 5 --json
+cxs find "xsearch" --cwd /Users/you/work/project --sort ended --exclude-session <current_session_uuid> -n 5 --json
 ```
 
 `find` defaults to relevance sorting. Do not treat default `find` order as time
@@ -151,13 +163,14 @@ before complete coverage is written.
 Pass `--best-effort` only when you explicitly want successful files written
 despite failures; best-effort sync does not record complete coverage.
 
-`sync` is not required before every query. Use `status --selector` to check
-coverage first. A fresh `{"kind":"all", ...}` coverage record covers narrower
+`sync` is not required before every query. Use `status --cwd` or
+`status --selector` to check coverage first. A fresh `{"kind":"all", ...}`
+coverage record covers narrower
 selectors under the same root; a high `stats.sessionCount` only means rows exist
 and is not itself a freshness proof.
 
 Indexes created before `cxs-v6-selector-provenance` should be refreshed with
-`sync --selector` so date selectors and read coverage use the current
+`sync --root`, `sync --cwd`, or `sync --selector` so date selectors and read coverage use the current
 `path_date` and source-root provenance fields.
 
 Older `cxs <= 0.2.0` indexes stored under `~/.cache/cxs/` are migrated

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 `cxs` 是一个面向本机 Codex session 日志的渐进式检索 CLI，当前架构是：
 
-`status -> sync --selector -> message/session recall -> session heuristic rerank -> read-range/read-page`
+`status -> sync --root/--cwd/--selector -> message/session recall -> session heuristic rerank -> read-range/read-page`
 
 它已经可用，但仍是轻量 retrieval 后端，不是完整的 resource-level retrieval 系统。
 
@@ -105,7 +105,7 @@ SQLite 访问层当前已经按 reader / writer 分流：
 - `reasoning_summary_text` 解析 `response_item.reasoning.summary`
 - `sessions_fts(title + summary_text + compact_text + reasoning_summary_text)` session-level recall
 - strict / best-effort 两种 sync 语义
-- explicit selector sync
+- explicit sync scope (`--root` / `--cwd` / `--selector`, canonicalized to selector)
 - source inventory
 - complete coverage 记录
 - manual eval 导出

--- a/docs/INDEX_COVERAGE_DESIGN.md
+++ b/docs/INDEX_COVERAGE_DESIGN.md
@@ -40,7 +40,7 @@ cxs index 是唯一可用于回答内容问题的真相源。
 
 CLI 面向 agent 输出 facts，不输出解释性标签。
 
-禁止使用需要自然语言解释的 shortcut selector 或 shortcut status。
+禁止使用需要自然语言解释的 shortcut selector 或 shortcut status。CLI 可以提供确定性的 `--cwd` / `--root` shorthand，但它们必须在进入 coverage/index 流程前还原为明确 selector。
 
 所有状态必须能还原为明确 selector。
 
@@ -187,8 +187,8 @@ Coverage 可以蕴含更窄 selector。
 
 约束：
 
-- selector 必须显式
-- 无 selector 是错误
+- 同步范围必须显式；`--cwd` / `--root` 只是确定性 shorthand，进入实现前必须 canonicalize 成 selector
+- 无 selector/scope 是错误
 - 严格成功才写 complete coverage
 - strict sync 必须把 selector 范围内的 index 收敛成当前 source snapshot 的投影；source 中已不存在、已被过滤或已不再可解析成 session 的旧 row 必须在写 coverage 前删除
 - best-effort 不能产生 complete coverage
@@ -246,7 +246,7 @@ agent 使用 cxs 的标准流程：
 
 ```text
 status
-select sync selector
+select sync scope (canonical selector)
 sync
 find or list
 read-range or read-page

--- a/skill-packages/cxs/SKILL.md
+++ b/skill-packages/cxs/SKILL.md
@@ -37,9 +37,9 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 | --- | --- | --- |
 | 用户问"之前 / 上次 / 我记得 / 我们讨论过" | `cxs status --json` | 先拿 source inventory 和 coverage |
 | 用户问"本机/这台 Mac 配过什么"、"有哪些服务器/VPS/节点/服务配置" | 先 `cxs status --json`,再用关键词 `服务器 VPS 节点 服务 域名 provider ssh sing-box launchd Cloudflare` 组合查 | 这类是本机配置考古,答案常在旧 Codex session 而不是当前 memory |
-| 用户问"本项目最近的对话" | 构造 `{"kind":"cwd",...}` selector 后先查 coverage,再 `list --sort ended` | 内容只从 cxs index 出来 |
-| 用户问"最新/最近 + 关键词" | 先确保 selector coverage,再 `find <query> --sort ended` | `find` 默认是相关性排序,不是时间排序 |
-| 用户给项目名 / cwd / 时间窗 | 显式构造 selector | cwd/date selector 比全文搜更稳 |
+| 用户问"本项目最近的对话" | `status --cwd <abs_cwd>` 查 coverage;必要时 `sync --cwd <abs_cwd>`;再 `list --selector '{"kind":"cwd","cwd":"<abs_cwd>"}' --sort ended` | 内容只从 cxs index 出来；selector JSON 不必手写 root |
+| 用户问"最新/最近 + 关键词" | 先确保 cwd/root coverage,再 `find <query> --cwd <abs_cwd> --sort ended` | `find` 默认是相关性排序,不是时间排序 |
+| 用户给项目名 / cwd / 时间窗 | cwd/root 用 `--cwd` / `--root` 快捷方式；日期窗才写 selector JSON | cwd/date selector 比全文搜更稳 |
 | 已锁定某 session,需要局部上下文 | `cxs read-range --seq` 或 `--query` | 局部扩窗,不冷启 `read-page` |
 
 **反例**(应该用别的工具):
@@ -54,12 +54,12 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 ## 工作流心法
 
 - **status → ensure coverage → find/list → read-range → read-page**:先确定覆盖边界，再回答内容问题
-- `sync` 只是写入/更新 SQLite index 和 coverage;查找本身不需要 sync。只有目标 selector 的 coverage 缺失或 stale 时才 `sync --selector`
-- 用 `status --selector '<json>' --json` 检查目标范围；`requestedCoverage.recommendedAction === "query"` 时直接查，`"sync"` 时才同步
+- `sync` 只是写入/更新 SQLite index 和 coverage;查找本身不需要 sync。只有目标范围 coverage 缺失或 stale 时才 `sync --cwd <path>` / `sync --root <dir>` / `sync --selector`
+- 用 `status --cwd <path> --json` 或 `status --selector '<json>' --json` 检查目标范围；`requestedCoverage.recommendedAction === "query"` 时直接查，`"sync"` 时才同步
 - `stats.sessionCount` 很多不等于目标范围有 v6 complete coverage；fresh `{"kind":"all",...}` coverage 可以覆盖 cwd/date 子 selector
-- "最新/最近 + 关键词"不要直接把默认 `find` 结果当最新；用 `find <query> --selector ... --sort ended`，必要时 `--exclude-session <current_uuid>` 排除当前会话/self-hit
+- "最新/最近 + 关键词"不要直接把默认 `find` 结果当最新；用 `find <query> --cwd <path> --sort ended` 或 `find <query> --root <dir> --sort ended`，必要时 `--exclude-session <current_uuid>` 排除当前会话/self-hit
 - `matchSource = "session"` 时 `matchSeq = null`;这种命中先 `read-page` 抽样,**不要伪造 `read-range --seq`**
-- 用户给 cwd 但不确定 sync 状态 → `status --json`;根据 source inventory 构造 cwd selector;再 `status --selector`;缺失/stale 才 `sync --selector`
+- 用户给 cwd 但不确定 sync 状态 → `status --json`;确认绝对 cwd 后跑 `status --cwd <path>`;缺失/stale 才 `sync --cwd <path>`
 - `cwd` 只是候选过滤,不是主题真相;还要再看 `title`、`summaryText`、开头几条 message
 - 同主题可能多个 uuid;按 `cwd / startedAt / matchCount` 选,不要按 title 脑补去重
 
@@ -73,7 +73,7 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 
 - `good`: 找到的 session/cwd/时间/上下文能支撑答案。
 - `query-refine`: 第一条 query 不理想，但通过改关键词、selector、`--sort ended`、`--exclude-session` 等正常使用方式解决了。
-- `coverage-issue`: 问题来自索引缺失/stale 或 selector 没覆盖；应说明需要 `status --selector` / `sync --selector`，不要归因给排序。
+- `coverage-issue`: 问题来自索引缺失/stale 或 selector 没覆盖；应说明需要 `status --cwd` / `sync --cwd` / `sync --root` / `status --selector` / `sync --selector`，不要归因给排序。
 - `skill-guidance-issue`: cxs CLI 没错，是 agent 没按 skill 流程用，比如把默认 `find` 当最新、伪造 `read-range --seq`、跳过 selector。
 - `dogfood-candidate`: 仍有可复现的不符合预期，例如 recall miss、明显错排、上下文窗口不对、session hit/message hit 行为让 agent 难以稳定使用。
 
@@ -93,8 +93,8 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 ## 前置
 
 - 先 `status --json` 看 `context / sourceInventory / coverage`
-- 先用 `status --selector '<json>' --json` 看目标 selector 的 `requestedCoverage`
-- 索引不存在、读命令返回 `index_unavailable`、或 `requestedCoverage.recommendedAction === "sync"` → `sync --selector '<json>'`
+- 先用 `status --cwd <path> --json` / `status --selector '<json>' --json` 看目标范围的 `requestedCoverage`
+- 索引不存在、读命令返回 `index_unavailable`、或 `requestedCoverage.recommendedAction === "sync"` → `sync --cwd <path>` / `sync --root <dir>` / `sync --selector '<json>'`
 - `sync` 默认严格模式;只有用户接受部分成功才加 `--best-effort`;best-effort 不写 complete coverage
 - 从别的 cwd 调用时,若默认 db 不对,显式传 `--db`
 
@@ -108,4 +108,4 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 - [`references/failure-cookbook.md`](references/failure-cookbook.md) — 错误症状速查 / `--json` error shape 速查
 - [`references/advanced-queries.md`](references/advanced-queries.md) — query 语义 / CJK 行为 / snippet 高亮
 
-# skill-sync: distributable cxs skill package, coverage-first recent-query workflow, 2026-04-30
+# skill-sync: distributable cxs skill package, coverage-first recent-query workflow, 2026-05-10

--- a/skill-packages/cxs/references/cli-surface.md
+++ b/skill-packages/cxs/references/cli-surface.md
@@ -12,7 +12,7 @@
 export CXS_BIN=/absolute/path/to/bin/cxs
 ```
 
-没有单独的 `init` 命令。首次安装后先跑 `status --json`，根据返回的 `context.root`、`sourceInventory.cwdGroups` 和问题范围构造 selector；再用 `status --selector '<json>' --json` 检查 coverage。只有 `requestedCoverage.recommendedAction === "sync"` 时才跑 `sync --selector '<json>'`。
+没有单独的 `init` 命令。首次安装后先跑 `status --json`，根据返回的 `context.root`、`sourceInventory.cwdGroups` 和问题范围选择 `--cwd` / `--root` / selector；再用 `status --cwd <path> --json` 或 `status --selector '<json>' --json` 检查 coverage。只有 `requestedCoverage.recommendedAction === "sync"` 时才跑对应的 `sync --cwd` / `sync --root` / `sync --selector`。
 
 缺少 cxs 索引时,`find` / `read-range` / `read-page` / `list` / `stats --json` 返回:
 
@@ -28,14 +28,17 @@ Example:
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo"}' --json
+"${CXS_BIN:-cxs}" status --cwd /Users/me/work/foo --json
+"${CXS_BIN:-cxs}" status --root /Users/me/.codex/archived_sessions --selector '{"kind":"all"}' --json
 ```
 
 `status --selector` 是只读 coverage check。看 `requestedCoverage`:
 
 - `recommendedAction: "query"`: 目标范围已有 fresh complete coverage，可直接 `find/list`
-- `recommendedAction: "sync"`: coverage 缺失或 stale，先 `sync --selector`
+- `recommendedAction: "sync"`: coverage 缺失或 stale，先跑同范围的 `sync --cwd` / `sync --root` / `sync --selector`
 - fresh `{"kind":"all",...}` coverage 可以覆盖 cwd/date 子 selector；`stats.sessionCount` 只是 rows 数，不等于 coverage 完整证明
+
+`root` 不再必须写进 selector JSON：传 `--root <dir>` 可补齐 `selector.root`；不传 `--root` 时使用默认 Codex sessions root。常见 cwd/root 范围优先用 CLI shortcut，日期范围再写 JSON。
 
 Selector shapes:
 
@@ -54,7 +57,9 @@ Options:
 
 | option | 说明 |
 | --- | --- |
-| `--selector <json>` | 必填;结构化同步范围 |
+| `--root <dir>` | 同步整个 sessions 根目录；也作为 selector 默认 root |
+| `--cwd <path>` | 同步指定 cwd selector；不必手写 selector JSON |
+| `--selector <json>` | 结构化同步范围；日期范围等高级范围用这个 |
 | `--db <path>` | 覆盖默认数据库 |
 | `--best-effort` | 即使部分文件失败也继续写入成功部分;不写 complete coverage |
 | `--json` | 成功时把 `SyncSummary` 打到 stdout |
@@ -64,8 +69,9 @@ Options:
 Example:
 
 ```bash
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo"}' --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"all","root":"/Users/me/.codex/sessions"}' --json 2>&1
+"${CXS_BIN:-cxs}" sync --cwd /Users/me/work/foo --json
+"${CXS_BIN:-cxs}" sync --root /Users/me/.codex/sessions --json 2>&1
+"${CXS_BIN:-cxs}" sync --root /Users/me/.codex/sessions --selector '{"kind":"cwd_date_range","cwd":"/Users/me/work/foo","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
 ```
 
 ## find
@@ -76,15 +82,18 @@ Example:
 
 ```bash
 "${CXS_BIN:-cxs}" find "cf tunnel" --json -n 5
-"${CXS_BIN:-cxs}" find "cf tunnel" --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo"}' --json -n 5
-"${CXS_BIN:-cxs}" find "xsearch" --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo"}' --sort ended --exclude-session <current_uuid> --json -n 5
+"${CXS_BIN:-cxs}" find "cf tunnel" --cwd /Users/me/work/foo --json -n 5
+"${CXS_BIN:-cxs}" find "ping pong" --root /Users/me/.codex/archived_sessions --json -n 5
+"${CXS_BIN:-cxs}" find "xsearch" --cwd /Users/me/work/foo --sort ended --exclude-session <current_uuid> --json -n 5
 ```
 
 Options:
 
 | option | 说明 |
 | --- | --- |
-| `--selector <json>` | 结构化查询范围 |
+| `--root <dir>` | 限定到整个 sessions 根目录；也作为 selector 默认 root |
+| `--cwd <path>` | 限定到指定 cwd selector |
+| `--selector <json>` | 结构化查询范围；可省略 `root` |
 | `--sort relevance|ended|started` | 默认 `relevance`;问"最新/最近 + 关键词"时用 `ended` |
 | `--exclude-session <uuid>` | 排除指定 session;可重复。用于排除当前会话/self-hit |
 | `-n, --limit <n>` | 返回条数 |
@@ -123,6 +132,8 @@ Example:
 
 ```bash
 "${CXS_BIN:-cxs}" list --selector '{"kind":"cwd_date_range","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo","fromDate":"2026-04-15","toDate":"2026-04-30"}' --sort ended --json
+"${CXS_BIN:-cxs}" list --root /Users/me/.codex/archived_sessions --sort ended --json
+"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","cwd":"/Users/me/work/foo"}' --sort ended --json
 ```
 
 ## stats

--- a/skill-packages/cxs/references/failure-cookbook.md
+++ b/skill-packages/cxs/references/failure-cookbook.md
@@ -4,15 +4,15 @@
 
 | 症状 | 先跑 | 处理 |
 | --- | --- | --- |
-| `find` 零结果但用户坚持存在 | `status --selector '<json>' --json` | 看目标 selector 的 `requestedCoverage`；必要时 `sync --selector`；再带 selector 查询 |
-| `sync` 非零退出带 per-file errors | `sync --selector '<json>' --json 2>&1` | 看 `errorDetails[]`；默认严格模式；只在允许部分成功时加 `--best-effort` |
-| `sync` 返回 `selector_required` | 原命令补 `--selector` | selector 必须显式，不存在默认范围 |
-| `find/list/stats/read-*` 输出 `index_unavailable` | `status --json` | 索引还没建立；选择 selector 后 `sync --selector` |
+| `find` 零结果但用户坚持存在 | `status --cwd <path> --json` 或 `status --selector '<json>' --json` | 看目标范围的 `requestedCoverage`；必要时 `sync --cwd` / `sync --root` / `sync --selector`；再带同范围查询 |
+| `sync` 非零退出带 per-file errors | `sync --root <dir> --json 2>&1` 或 `sync --selector '<json>' --json 2>&1` | 看 `errorDetails[]`；默认严格模式；只在允许部分成功时加 `--best-effort` |
+| `sync` 返回 `selector_required` | 原命令补 `--root`、`--cwd` 或 `--selector` | sync 必须显式给范围；不需要把 root 写进 JSON |
+| `find/list/stats/read-*` 输出 `index_unavailable` | `status --json` | 索引还没建立；选择范围后 `sync --root` / `sync --cwd` / `sync --selector` |
 | `stats/list/find` 报 `database is locked` | 原命令重试一次 | 多半是 SQLite 忙；仍失败就先跳过 `stats` 直接读 |
 | 同一主题多条 uuid | `find -n 10 --json` | 按 `startedAt`、`cwd`、`matchCount` 选 |
 | 最新/最近 + 关键词被当前会话抢结果 | `find <query> --sort ended --exclude-session <uuid>` | 默认 `find` 是 relevance 排序；时间问题显式用 `--sort ended` 并排除 self-hit |
 | 中文/CJK 零结果 | 无 | 换至少两字中文、英文关键词，或先用 selector 缩范围 |
-| 用户问“最近本项目讨论了什么” | `status --selector '<cwd selector>' --json` | coverage fresh 直接 `list --selector`;缺失/stale 才同步 |
+| 用户问“最近本项目讨论了什么” | `status --cwd <abs_cwd> --json` | coverage fresh 直接 `list --selector '{"kind":"cwd","cwd":"..."}'`;缺失/stale 才同步 |
 | 用户说“在 X 项目里” | `status --json` | 从 `sourceInventory.cwdGroups` 选择 cwd selector |
 | 从其他 cwd 调用找不到 db | `stats --json` | 看 `dbPath`；必要时显式传 `--db` |
 
@@ -22,11 +22,11 @@
 "${CXS_BIN:-cxs}" status --json
 ```
 
-如果目标范围没有 fresh coverage，先同步明确 selector：
+如果目标范围没有 fresh coverage，先同步明确范围。cwd/root 用快捷方式，日期窗再用 selector：
 
 ```bash
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo"}' --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo"}'
+"${CXS_BIN:-cxs}" status --cwd /Users/me/work/foo --json
+"${CXS_BIN:-cxs}" sync --cwd /Users/me/work/foo
 ```
 
 如果 `status --selector` 返回 `recommendedAction: "query"`，跳过 `sync`。
@@ -36,7 +36,7 @@
 ## Sync non-zero with per-file errors
 
 ```bash
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"all","root":"/Users/me/.codex/sessions"}' --json 2>&1
+"${CXS_BIN:-cxs}" sync --root /Users/me/.codex/sessions --json 2>&1
 ```
 
 处理规则：
@@ -47,7 +47,7 @@
 
 ## index_unavailable
 
-`find` / `read-range` / `read-page` / `list` / `stats` 都读 cxs 自己的 SQLite 索引。第一次安装后还没跑过 `sync --selector` 时，这些命令会在 `--json` 模式下返回:
+`find` / `read-range` / `read-page` / `list` / `stats` 都读 cxs 自己的 SQLite 索引。第一次安装后还没跑过 `sync --root` / `sync --cwd` / `sync --selector` 时，这些命令会在 `--json` 模式下返回:
 
 ```json
 {
@@ -64,10 +64,10 @@
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"all","root":"/Users/me/.codex/sessions"}'
+"${CXS_BIN:-cxs}" sync --root /Users/me/.codex/sessions
 ```
 
-没有单独 `init` 命令；`sync --selector` 会创建并更新索引。
+没有单独 `init` 命令；`sync --root` / `sync --cwd` / `sync --selector` 会创建并更新索引。
 
 ## Database is locked or SQLITE_BUSY
 
@@ -77,13 +77,13 @@
 
 ## Current project discussion query
 
-用户问“最近本项目讨论了什么”时，默认先用当前 repo 绝对路径构造 cwd selector：
+用户问“最近本项目讨论了什么”时，默认先用当前 repo 绝对路径走 cwd shortcut：
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
-"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --sort ended -n 8 --json
+"${CXS_BIN:-cxs}" status --cwd /absolute/path/to/current/repo --json
+"${CXS_BIN:-cxs}" sync --cwd /absolute/path/to/current/repo --json
+"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","cwd":"/absolute/path/to/current/repo"}' --sort ended -n 8 --json
 ```
 
 如果 `status --selector` 返回 `recommendedAction: "query"`，跳过 `sync`。
@@ -100,9 +100,10 @@
 用户问“最新一次 X / 最近哪个 session 提到 X”时:
 
 ```bash
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
+"${CXS_BIN:-cxs}" status --cwd /absolute/path/to/current/repo --json
 # recommendedAction 为 "sync" 时才同步
-"${CXS_BIN:-cxs}" find "X" --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --sort ended --exclude-session <current_session_uuid> --json -n 5
+"${CXS_BIN:-cxs}" sync --cwd /absolute/path/to/current/repo --json
+"${CXS_BIN:-cxs}" find "X" --cwd /absolute/path/to/current/repo --sort ended --exclude-session <current_session_uuid> --json -n 5
 ```
 
 不要直接用默认 `find "X"` 下“最新”结论；默认排序是 relevance。

--- a/skill-packages/cxs/references/progressive-workflow.md
+++ b/skill-packages/cxs/references/progressive-workflow.md
@@ -3,8 +3,8 @@
 ## 默认流程
 
 1. `status --json` 拿 source inventory 和 coverage
-2. 选择明确 selector,用 `status --selector '<json>' --json` 检查 `requestedCoverage`
-3. 如果 `recommendedAction` 是 `"sync"` 才 `sync --selector`;如果是 `"query"` 直接查
+2. 选择明确范围,用 `status --cwd <path>` 或 `status --selector '<json>' --json` 检查 `requestedCoverage`
+3. 如果 `recommendedAction` 是 `"sync"` 才跑同范围 `sync --cwd` / `sync --root` / `sync --selector`;如果是 `"query"` 直接查
 4. `find` 或 `list` 拿候选 session 和命中锚点
 5. `read-range` 在最佳候选周围扩局部上下文
 6. `read-page` 只在局部窗口仍不够时翻整页
@@ -13,7 +13,7 @@
 
 - 没有 `sessionUuid` 时，不要冷启动 `read-page`
 - `sync` 只负责更新 index/coverage;查找不需要每次 sync
-- 用户给了 `cwd` 或时间窗口:构造同范围 selector;先确认 coverage;缺失/stale 才同步;查询时继续带同一个 selector
+- 用户给了 `cwd` 或时间窗口:cwd/root 优先用 `--cwd` / `--root`;日期窗口用 selector JSON;先确认 coverage;缺失/stale 才同步;查询时继续带同一个范围
 - 用户问"最新/最近 + 关键词":不要用默认 `find` 当时间结论;用 `find <query> --sort ended`,并用 `--exclude-session <current_uuid>` 排除当前会话/self-hit
 - 已锁定 session 但锚点不对时，用 `read-range --query`
 - `cwd` 只是候选过滤，不是主题真相；还要再看 `title`、`summaryText` 和开头几条 message
@@ -24,9 +24,9 @@
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" status --selector '{"kind":"all","root":"/Users/me/.codex/sessions"}' --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"all","root":"/Users/me/.codex/sessions"}' --json
-"${CXS_BIN:-cxs}" find "cf tunnel" --json -n 5
+"${CXS_BIN:-cxs}" status --root /Users/me/.codex/sessions --selector '{"kind":"all"}' --json
+"${CXS_BIN:-cxs}" sync --root /Users/me/.codex/sessions --json
+"${CXS_BIN:-cxs}" find "cf tunnel" --root /Users/me/.codex/sessions --json -n 5
 ```
 
 如果 `status --selector` 返回 `recommendedAction: "query"`，跳过 `sync`。
@@ -51,9 +51,9 @@
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd_date_range","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/hammerspoon","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd_date_range","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/hammerspoon","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
-"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd_date_range","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/hammerspoon","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
+"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd_date_range","cwd":"/Users/me/work/hammerspoon","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
+"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd_date_range","cwd":"/Users/me/work/hammerspoon","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
+"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd_date_range","cwd":"/Users/me/work/hammerspoon","fromDate":"2026-04-15","toDate":"2026-04-30"}' --json
 ```
 
 如果 `status --selector` 返回 `recommendedAction: "query"`，跳过 `sync`。
@@ -72,9 +72,9 @@
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
-"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --sort ended -n 8 --json
+"${CXS_BIN:-cxs}" status --cwd /absolute/path/to/current/repo --json
+"${CXS_BIN:-cxs}" sync --cwd /absolute/path/to/current/repo --json
+"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","cwd":"/absolute/path/to/current/repo"}' --sort ended -n 8 --json
 ```
 
 如果 `status --selector` 返回 `recommendedAction: "query"`，跳过 `sync`。
@@ -94,16 +94,16 @@
 
 ```bash
 "${CXS_BIN:-cxs}" status --json
-"${CXS_BIN:-cxs}" status --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
+"${CXS_BIN:-cxs}" status --cwd /absolute/path/to/current/repo --json
 # 如果 recommendedAction 是 "sync":
-"${CXS_BIN:-cxs}" sync --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --json
-"${CXS_BIN:-cxs}" find "xsearch" --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --sort ended --exclude-session <current_session_uuid> --json -n 5
+"${CXS_BIN:-cxs}" sync --cwd /absolute/path/to/current/repo --json
+"${CXS_BIN:-cxs}" find "xsearch" --cwd /absolute/path/to/current/repo --sort ended --exclude-session <current_session_uuid> --json -n 5
 ```
 
 如果不知道当前 session uuid，先从最近列表识别当前 self-hit，再把它传给 `--exclude-session`：
 
 ```bash
-"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","root":"/Users/me/.codex/sessions","cwd":"/absolute/path/to/current/repo"}' --sort ended -n 5 --json
+"${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","cwd":"/absolute/path/to/current/repo"}' --sort ended -n 5 --json
 ```
 
 ## 来源

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -106,6 +106,43 @@ describe("cxs cli", () => {
     expect(payload.requestedCoverage.sourceFileCount).toBe(1);
   });
 
+  test("status --cwd builds a cwd selector with --root", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-status-cwd-shortcut-"));
+    tempDirs.push(base);
+    const root = join(base, "sessions");
+    const sessionsRoot = join(root, "2026", "04", "20");
+    mkdirSync(sessionsRoot, { recursive: true });
+    writeFileSync(
+      join(sessionsRoot, "rollout-2026-04-20T10-00-00-10101010-2020-4010-8010-101010101010.jsonl"),
+      [
+        line("session_meta", { id: "10101010-2020-4010-8010-101010101010", cwd: "/tmp/status-cwd-shortcut" }),
+        line("event_msg", { type: "user_message", message: "status cwd shortcut" }),
+      ].join("\n"),
+    );
+
+    const result = await runCli([
+      "status",
+      "--root",
+      root,
+      "--cwd",
+      "/tmp/status-cwd-shortcut",
+      "--db",
+      join(base, "missing.sqlite"),
+      "--json",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout) as {
+      requestedCoverage: { requested: { kind: string; root: string; cwd?: string }; sourceFileCount: number };
+    };
+    expect(payload.requestedCoverage.requested).toMatchObject({
+      kind: "cwd",
+      root,
+      cwd: "/tmp/status-cwd-shortcut",
+    });
+    expect(payload.requestedCoverage.sourceFileCount).toBe(1);
+  });
+
   test("sync requires an explicit selector", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-cli-sync-selector-required-"));
     tempDirs.push(base);
@@ -157,6 +194,134 @@ describe("cxs cli", () => {
     expect(findPayload.coverage.complete).toBe(true);
     expect(findPayload.coverage.freshness).toBe("not_checked");
     expect(findPayload.results.map((result) => result.cwd)).toEqual(["/tmp/alpha"]);
+  });
+
+  test("sync and find support --cwd/--root without handwritten selector JSON", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-cwd-shortcut-"));
+    tempDirs.push(base);
+    const root = join(base, "sessions");
+    const day = join(root, "2026", "04", "21");
+    mkdirSync(day, { recursive: true });
+    writeFileSync(
+      join(day, "rollout-2026-04-21T10-00-00-22222222-aaaa-4222-8222-222222222222.jsonl"),
+      [
+        line("session_meta", { id: "22222222-aaaa-4222-8222-222222222222", cwd: "/tmp/shortcut-alpha" }),
+        line("event_msg", { type: "user_message", message: "shortcut needle alpha" }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(day, "rollout-2026-04-21T11-00-00-33333333-bbbb-4333-8333-333333333333.jsonl"),
+      [
+        line("session_meta", { id: "33333333-bbbb-4333-8333-333333333333", cwd: "/tmp/shortcut-beta" }),
+        line("event_msg", { type: "user_message", message: "shortcut needle beta" }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const synced = await runCli(["sync", "--root", root, "--cwd", "/tmp/shortcut-alpha", "--db", dbPath, "--json"]);
+    expect(synced.exitCode).toBe(0);
+    const syncPayload = JSON.parse(synced.stdout) as { coverage: { selector: { kind: string; root: string; cwd?: string } } };
+    expect(syncPayload.coverage.selector).toMatchObject({ kind: "cwd", root, cwd: "/tmp/shortcut-alpha" });
+
+    const found = await runCli(["find", "shortcut needle", "--root", root, "--cwd", "/tmp/shortcut-alpha", "--db", dbPath, "--json"]);
+    expect(found.exitCode).toBe(0);
+    const findPayload = JSON.parse(found.stdout) as { results: Array<{ cwd: string }> };
+    expect(findPayload.results.map((result) => result.cwd)).toEqual(["/tmp/shortcut-alpha"]);
+  });
+
+  test("sync find and list support --root as an all-root selector shortcut", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-root-shortcut-"));
+    tempDirs.push(base);
+    const rootA = join(base, "sessions-a");
+    const rootB = join(base, "sessions-b");
+    const dayA = join(rootA, "2026", "04", "21");
+    const dayB = join(rootB, "2026", "04", "21");
+    mkdirSync(dayA, { recursive: true });
+    mkdirSync(dayB, { recursive: true });
+    writeFileSync(
+      join(dayA, "rollout-2026-04-21T10-00-00-aaaaaaaa-1111-4aaa-8aaa-aaaaaaaaaaaa.jsonl"),
+      [
+        line("session_meta", { id: "aaaaaaaa-1111-4aaa-8aaa-aaaaaaaaaaaa", cwd: "/tmp/root-shortcut-alpha" }),
+        line("event_msg", { type: "user_message", message: "root shortcut shared needle alpha" }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dayB, "rollout-2026-04-21T11-00-00-bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb.jsonl"),
+      [
+        line("session_meta", { id: "bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb", cwd: "/tmp/root-shortcut-beta" }),
+        line("event_msg", { type: "user_message", message: "root shortcut shared needle beta" }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const syncA = await runCli(["sync", "--root", rootA, "--db", dbPath, "--json"]);
+    expect(syncA.exitCode).toBe(0);
+    const syncPayload = JSON.parse(syncA.stdout) as { coverage: { selector: { kind: string; root: string } } };
+    expect(syncPayload.coverage.selector).toEqual({ kind: "all", root: rootA });
+
+    const syncB = await runCli(["sync", "--root", rootB, "--db", dbPath, "--json"]);
+    expect(syncB.exitCode).toBe(0);
+
+    const found = await runCli(["find", "root shortcut shared needle", "--root", rootB, "--db", dbPath, "--json"]);
+    expect(found.exitCode).toBe(0);
+    const findPayload = JSON.parse(found.stdout) as { results: Array<{ sessionUuid: string }> };
+    expect(findPayload.results.map((result) => result.sessionUuid)).toEqual(["bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb"]);
+
+    const listed = await runCli(["list", "--root", rootB, "--db", dbPath, "--json"]);
+    expect(listed.exitCode).toBe(0);
+    const listPayload = JSON.parse(listed.stdout) as { results: Array<{ sessionUuid: string }> };
+    expect(listPayload.results.map((result) => result.sessionUuid)).toEqual(["bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb"]);
+  });
+
+  test("selector JSON can omit root when --root is provided", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-selector-default-root-"));
+    tempDirs.push(base);
+    const root = join(base, "sessions");
+    const day = join(root, "2026", "04", "21");
+    mkdirSync(day, { recursive: true });
+    writeFileSync(
+      join(day, "rollout-2026-04-21T10-00-00-44444444-aaaa-4444-8444-444444444444.jsonl"),
+      [
+        line("session_meta", { id: "44444444-aaaa-4444-8444-444444444444", cwd: "/tmp/selector-default-root" }),
+        line("event_msg", { type: "user_message", message: "default root needle" }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const selectorWithoutRoot = JSON.stringify({ kind: "cwd", cwd: "/tmp/selector-default-root" });
+    const synced = await runCli(["sync", "--root", root, "--selector", selectorWithoutRoot, "--db", dbPath, "--json"]);
+    expect(synced.exitCode).toBe(0);
+
+    const found = await runCli(["find", "default root needle", "--root", root, "--selector", selectorWithoutRoot, "--db", dbPath, "--json"]);
+    expect(found.exitCode).toBe(0);
+    const payload = JSON.parse(found.stdout) as {
+      results: Array<{ sessionUuid: string }>;
+      coverage: { complete: boolean; coveringSelectors: Array<{ selector: { root: string } }> };
+    };
+    expect(payload.results[0]?.sessionUuid).toBe("44444444-aaaa-4444-8444-444444444444");
+    expect(payload.coverage.complete).toBe(true);
+    expect(payload.coverage.coveringSelectors[0]?.selector.root).toBe(root);
+  });
+
+  test("find rejects combining --selector and --cwd", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-selector-cwd-conflict-"));
+    tempDirs.push(base);
+    const result = await runCli([
+      "find",
+      "needle",
+      "--selector",
+      JSON.stringify({ kind: "all", root: join(base, "sessions") }),
+      "--cwd",
+      "/tmp/project",
+      "--db",
+      join(base, "index.sqlite"),
+      "--json",
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    const payload = JSON.parse(result.stdout) as { error: { code: string; message: string } };
+    expect(payload.error.code).toBe("invalid_selector");
+    expect(payload.error.message).toContain("cannot be combined");
   });
 
   test("status marks coverage stale when selected source files change", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import packageJson from "../package.json" with { type: "json" };
 import {
+  DEFAULT_CODEX_DIR,
   DEFAULT_DB_PATH,
   migrateLegacyCacheDirIfNeeded,
 } from "./env";
@@ -27,7 +28,7 @@ import {
   getMessageRange,
   listSessionSummaries,
 } from "./query";
-import { parseSelectorJson, SelectorParseError } from "./selector";
+import { canonicalizeSelector, parseSelectorJson, SelectorParseError } from "./selector";
 import { collectStatus } from "./status";
 import { SyncLockTimeoutError } from "./sync-lock";
 import type { FindSort, Selector, SessionListSort } from "./types";
@@ -42,13 +43,14 @@ program
 program
   .command("status")
   .description("返回执行上下文、source inventory、index 与 coverage 状态")
-  .option("--root <dir>", "覆盖默认 sessions 根目录")
+  .option("--root <dir>", "覆盖默认 sessions 根目录，也作为 selector 默认 root")
   .option("--selector <json>", "检查指定 selector 的 coverage/freshness（只读，不同步）")
+  .option("--cwd <path>", "检查指定 cwd selector 的 coverage/freshness")
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--json", "输出 JSON")
   .action(async (options) => {
     try {
-      const selector = optionalSelector(options.selector);
+      const selector = optionalSelector(options);
       const status = await collectStatus({ rootDir: options.root, dbPath: options.db, cwd: process.cwd(), selector: selector ?? undefined });
       if (options.json) {
         console.log(JSON.stringify(status, null, 2));
@@ -67,13 +69,15 @@ program
 program
   .command("sync")
   .description("扫描并同步本地 Codex sessions 到 SQLite 索引")
+  .option("--root <dir>", "同步指定 sessions 根目录；也作为 selector 默认 root")
   .option("--selector <json>", "结构化同步范围 JSON")
+  .option("--cwd <path>", "同步指定 cwd selector")
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--best-effort", "即使部分文件失败也继续写入可成功部分")
   .option("--json", "输出 JSON")
   .action(async (options) => {
     try {
-      const selector = requireSelector(options.selector);
+      const selector = requireSelector(options);
       const summary = await syncSessions({
         dbPath: options.db,
         selector,
@@ -115,7 +119,9 @@ program
   .command("find <query>")
   .description("搜索相关 session，返回最小必要命中")
   .option("-n, --limit <n>", "返回条数", "10")
+  .option("--root <dir>", "限定到指定 sessions 根目录；也作为 selector 默认 root")
   .option("--selector <json>", "结构化查询范围 JSON")
+  .option("--cwd <path>", "限定到指定 cwd selector")
   .option("--sort <key>", "排序键：relevance|ended|started", "relevance")
   .option("--exclude-session <uuid>", "排除指定 session_uuid；可重复", collectValues, [])
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
@@ -123,7 +129,7 @@ program
   .action((query, options) => {
     runReadCommand(Boolean(options.json), () => {
       const limit = parsePositiveInt(options.limit, 10);
-      const selector = optionalSelector(options.selector);
+      const selector = optionalSelector({ ...options, rootOnlySelector: true });
       const sort = normalizeFindSort(options.sort);
       const result = findSessions(options.db, query, limit, selector, {
         sort,
@@ -203,6 +209,7 @@ program
   .description("列出已索引的 session（不做全文检索）")
   .option("--cwd <needle>", "cwd 子串过滤（大小写不敏感）")
   .option("--since <iso>", "只看 ended_at >= 指定时间的 session")
+  .option("--root <dir>", "限定到指定 sessions 根目录；也作为 selector 默认 root")
   .option("--selector <json>", "结构化查询范围 JSON")
   .option("--sort <key>", "排序键：ended|started|messages", "ended")
   .option("-n, --limit <n>", "返回条数", "20")
@@ -211,7 +218,7 @@ program
   .action((options) => {
     runReadCommand(Boolean(options.json), () => {
       const sort = normalizeListSort(options.sort);
-      const selector = optionalSelector(options.selector);
+      const selector = optionalSelector({ selector: options.selector, root: options.root, rootOnlySelector: true });
       const result = listSessionSummaries(options.db, {
         cwd: options.cwd,
         since: options.since,
@@ -330,13 +337,26 @@ function emitSelectorError(error: SelectorParseError, jsonMode: boolean): void {
   process.exitCode = 1;
 }
 
-function requireSelector(value: string | undefined): Selector {
-  if (!value) {
-    throw new SelectorParseError("sync requires --selector with an explicit selector JSON object");
+function requireSelector(options: { selector?: string; root?: string; cwd?: string }): Selector {
+  const selector = optionalSelector({
+    selector: options.selector,
+    root: options.root,
+    cwd: options.cwd,
+    rootOnlySelector: true,
+  });
+  if (!selector) {
+    throw new SelectorParseError("sync requires --selector, --cwd, or --root with an explicit scope");
   }
-  return parseSelectorJson(value);
+  return selector;
 }
 
-function optionalSelector(value: string | undefined): Selector | null {
-  return value ? parseSelectorJson(value) : null;
+function optionalSelector(options: { selector?: string; root?: string; cwd?: string; rootOnlySelector?: boolean }): Selector | null {
+  if (options.selector && options.cwd) {
+    throw new SelectorParseError("--selector and --cwd cannot be combined");
+  }
+  const root = options.root ?? DEFAULT_CODEX_DIR;
+  if (options.selector) return parseSelectorJson(options.selector, { defaultRoot: root });
+  if (options.cwd) return canonicalizeSelector({ kind: "cwd", root, cwd: options.cwd });
+  if (options.rootOnlySelector && options.root) return canonicalizeSelector({ kind: "all", root });
+  return null;
 }

--- a/src/selector.test.ts
+++ b/src/selector.test.ts
@@ -9,6 +9,14 @@ describe("selector", () => {
     });
   });
 
+  test("can fill a missing selector root from caller defaults", () => {
+    expect(canonicalizeSelector({ kind: "cwd", cwd: "/tmp/project" }, { defaultRoot: "/tmp/../tmp/cxs-root" })).toEqual({
+      kind: "cwd",
+      root: "/tmp/cxs-root",
+      cwd: "/tmp/project",
+    });
+  });
+
   test("rejects date ranges with fromDate after toDate", () => {
     expect(() =>
       canonicalizeSelector({

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -3,14 +3,18 @@ import type { Selector } from "./types";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-export function parseSelectorJson(value: string): Selector {
+export interface SelectorDefaults {
+  defaultRoot?: string;
+}
+
+export function parseSelectorJson(value: string, defaults: SelectorDefaults = {}): Selector {
   let raw: unknown;
   try {
     raw = JSON.parse(value) as unknown;
   } catch (error) {
     throw new SelectorParseError(`invalid selector JSON: ${describeError(error)}`);
   }
-  return canonicalizeSelector(raw);
+  return canonicalizeSelector(raw, defaults);
 }
 
 export class SelectorParseError extends Error {
@@ -20,10 +24,10 @@ export class SelectorParseError extends Error {
   }
 }
 
-export function canonicalizeSelector(value: unknown): Selector {
+export function canonicalizeSelector(value: unknown, defaults: SelectorDefaults = {}): Selector {
   if (!isRecord(value)) throw new SelectorParseError("selector must be an object");
   const kind = value.kind;
-  const root = requireString(value.root, "root");
+  const root = requireString(value.root ?? defaults.defaultRoot, "root");
   const base = { root: resolve(root) };
 
   if (kind === "all") {


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does -->

## Mainline Intent

<!--
This section is auto-filled by mainline pr-description.
It is for human reviewers; Mainline does not parse it.
-->

## Tested

<!-- How was this tested? -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified CLI selector usage by adding `--cwd` and `--root` shortcuts and auto-filling selector `root`. This makes common flows shorter and safer while keeping advanced selector JSON supported.

- **New Features**
  - `status`, `sync`, `find`, and `list` now accept `--cwd` and `--root`; `--root` also sets the default selector root.
  - Selector JSON may omit `"root"`; it’s filled from `--root` or the default Codex dir.
  - `sync` requires an explicit scope via `--selector`/`--cwd`/`--root`, with clearer errors.
  - Prevent combining `--selector` and `--cwd`; returns `invalid_selector` with a clear message.
  - Updated docs and examples to prefer shortcuts over handwritten root.
  - Added tests for cwd/root shortcuts, default-root fill, and option conflicts.

<sup>Written for commit df15a97911079f32b1b179c4e2a1ad4fa9e0cb3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

