### PR TITLE
fix(sync): 默认保留已索引历史

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,13 @@ export CXS_DATA_DIR="$HOME/.config/cxs"
 
 Sync is strict by default. If any selected file fails to parse or write, `sync`
 exits non-zero with per-file diagnostics and does not commit partial coverage.
-On success, strict sync reconciles the selected index slice to the current source
-snapshot: selected sessions whose source JSONL no longer exists are removed
-before complete coverage is written.
+On success, strict sync updates the selected index slice for files that are
+currently visible in the source snapshot and writes complete coverage for that
+snapshot. Previously indexed sessions whose source JSONL later disappears are
+retained by default, so raw log maintenance does not make historical `cxs find`
+or `read-*` results disappear.
+Pass `--prune` only when you explicitly want to delete indexed sessions that are
+no longer present in the selected source snapshot.
 Pass `--best-effort` only when you explicitly want successful files written
 despite failures; best-effort sync does not record complete coverage.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,9 +26,9 @@
 
 [status.ts](/Users/envvar/work/repos/cxs/src/status.ts) 返回执行上下文、source inventory、index 状态与 coverage 状态。它可以扫描 raw sessions 的 metadata，但不回答内容问题。
 
-[indexer.ts](/Users/envvar/work/repos/cxs/src/indexer.ts) 按显式 selector 扫描 `~/.codex/sessions` 下的 JSONL session 文件，按文件 `mtime`、`size` 和 `indexVersion` 做增量判断。
+[indexer.ts](/Users/envvar/work/repos/cxs/src/indexer.ts) 按显式 selector 扫描 Codex JSONL session source，按文件 `mtime`、`size` 和 `indexVersion` 做增量判断。
 
-strict sync 在写 complete coverage 前会 reconcile selector 范围：当前 source snapshot 中不存在、被过滤或不能解析成 session 的旧 index row 会被删除。
+strict sync 默认只更新当前 source snapshot 中仍可见的文件，并保留已经进入 SQLite 的旧 session。这样 raw JSONL 的维护、移动或删除不会让 cxs 的历史查询丢失。只有显式传 `--prune` 时，sync 才会把 selector 范围收敛成当前 source snapshot，并删除 source 中已不存在的旧 index row。当前 source 中仍存在但被过滤或不能解析成 session 的文件仍按当前状态处理。
 
 [parser.ts](/Users/envvar/work/repos/cxs/src/parser.ts) 只抽取 `event_msg` 里的：
 

--- a/docs/INDEX_COVERAGE_DESIGN.md
+++ b/docs/INDEX_COVERAGE_DESIGN.md
@@ -190,7 +190,9 @@ Coverage 可以蕴含更窄 selector。
 - 同步范围必须显式；`--cwd` / `--root` 只是确定性 shorthand，进入实现前必须 canonicalize 成 selector
 - 无 selector/scope 是错误
 - 严格成功才写 complete coverage
-- strict sync 必须把 selector 范围内的 index 收敛成当前 source snapshot 的投影；source 中已不存在、已被过滤或已不再可解析成 session 的旧 row 必须在写 coverage 前删除
+- strict sync 默认保留 selector 范围内已索引、但当前 source snapshot 中已消失的旧 row；raw JSONL 的维护、移动或删除不应让 cxs 历史查询丢失
+- `--prune` 才把 selector 范围内的 index 收敛成当前 source snapshot 的投影，并删除 source 中已不存在的旧 row
+- source 中仍存在但被过滤或已不再可解析成 session 的当前文件，仍应从 index 中删除或报错
 - best-effort 不能产生 complete coverage
 
 ### find

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@act0r/cxs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@act0r/cxs",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@act0r/cxs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Progressive search CLI for local Codex session logs",
   "license": "MIT",

--- a/skill-packages/cxs/SKILL.md
+++ b/skill-packages/cxs/SKILL.md
@@ -5,7 +5,7 @@ description: "Use proactively for local Codex history and personal setup archaeo
 
 # cxs
 
-用 `cxs` 在 `~/.codex/sessions` 里检索旧 Codex 对话。心法:**先定位候选 session,再局部扩上下文,最后才翻全页**——不要冷启动整批 JSONL。
+用 `cxs` 在自己的 SQLite index 里检索旧 Codex 对话。Codex 的 raw sessions 只是 ingest source；不要让用户切换 source root 去追 raw 文件位置。心法:**先定位候选 session,再局部扩上下文,最后才翻全页**——不要冷启动整批 JSONL。
 
 ## 安装(两步)
 
@@ -55,6 +55,7 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 
 - **status → ensure coverage → find/list → read-range → read-page**:先确定覆盖边界，再回答内容问题
 - `sync` 只是写入/更新 SQLite index 和 coverage;查找本身不需要 sync。只有目标范围 coverage 缺失或 stale 时才 `sync --cwd <path>` / `sync --root <dir>` / `sync --selector`
+- `sync` 默认保留已索引历史；raw JSONL 从 source snapshot 中消失后，不要引导用户改查另一个 root。只有用户明确要让 cxs 丢弃 source 中已经消失的旧记录时才用 `sync --prune`
 - 用 `status --cwd <path> --json` 或 `status --selector '<json>' --json` 检查目标范围；`requestedCoverage.recommendedAction === "query"` 时直接查，`"sync"` 时才同步
 - `stats.sessionCount` 很多不等于目标范围有 v6 complete coverage；fresh `{"kind":"all",...}` coverage 可以覆盖 cwd/date 子 selector
 - "最新/最近 + 关键词"不要直接把默认 `find` 结果当最新；用 `find <query> --cwd <path> --sort ended` 或 `find <query> --root <dir> --sort ended`，必要时 `--exclude-session <current_uuid>` 排除当前会话/self-hit
@@ -96,6 +97,7 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 - 先用 `status --cwd <path> --json` / `status --selector '<json>' --json` 看目标范围的 `requestedCoverage`
 - 索引不存在、读命令返回 `index_unavailable`、或 `requestedCoverage.recommendedAction === "sync"` → `sync --cwd <path>` / `sync --root <dir>` / `sync --selector '<json>'`
 - `sync` 默认严格模式;只有用户接受部分成功才加 `--best-effort`;best-effort 不写 complete coverage
+- `sync --prune` 是显式清理动作,会删除所选 source 中已经消失的旧索引记录；普通历史查询和日常增量同步不要加
 - 从别的 cwd 调用时,若默认 db 不对,显式传 `--db`
 
 ## 参考
@@ -108,4 +110,4 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 - [`references/failure-cookbook.md`](references/failure-cookbook.md) — 错误症状速查 / `--json` error shape 速查
 - [`references/advanced-queries.md`](references/advanced-queries.md) — query 语义 / CJK 行为 / snippet 高亮
 
-# skill-sync: distributable cxs skill package, coverage-first recent-query workflow, 2026-05-10
+# skill-sync: distributable cxs skill package, coverage-first retained-index workflow, 2026-05-19

--- a/skill-packages/cxs/references/cli-surface.md
+++ b/skill-packages/cxs/references/cli-surface.md
@@ -29,7 +29,7 @@ Example:
 ```bash
 "${CXS_BIN:-cxs}" status --json
 "${CXS_BIN:-cxs}" status --cwd /Users/me/work/foo --json
-"${CXS_BIN:-cxs}" status --root /Users/me/.codex/archived_sessions --selector '{"kind":"all"}' --json
+"${CXS_BIN:-cxs}" status --root /Users/me/.codex/sessions --selector '{"kind":"all"}' --json
 ```
 
 `status --selector` 是只读 coverage check。看 `requestedCoverage`:
@@ -62,9 +62,12 @@ Options:
 | `--selector <json>` | 结构化同步范围；日期范围等高级范围用这个 |
 | `--db <path>` | 覆盖默认数据库 |
 | `--best-effort` | 即使部分文件失败也继续写入成功部分;不写 complete coverage |
+| `--prune` | 显式删除所选 source 中已经消失的旧索引记录 |
 | `--json` | 成功时把 `SyncSummary` 打到 stdout |
 
-严格模式成功时，`sync` 会先把 selector 范围内的 index 与当前 source snapshot 对齐；源文件已删除、被过滤或不再能解析成 session 的旧 row 会被移除，并计入 `removed`。
+严格模式成功时，`sync` 会更新当前 source snapshot 中仍可见的文件，并写 complete coverage。默认保留已经索引过、但 raw JSONL 后来从 source 中消失的旧 session；查询时不需要切换 root 去追 raw 文件位置。
+
+只有显式传 `--prune` 时，`sync` 才把 selector 范围内的 index 与当前 source snapshot 对齐；源文件已删除的旧 row 会被移除，并计入 `removed`。源文件仍存在但被过滤或不再能解析成 session 时，仍按当前文件状态删除或报错。
 
 Example:
 
@@ -83,7 +86,7 @@ Example:
 ```bash
 "${CXS_BIN:-cxs}" find "cf tunnel" --json -n 5
 "${CXS_BIN:-cxs}" find "cf tunnel" --cwd /Users/me/work/foo --json -n 5
-"${CXS_BIN:-cxs}" find "ping pong" --root /Users/me/.codex/archived_sessions --json -n 5
+"${CXS_BIN:-cxs}" find "ping pong" --root /Users/me/.codex/sessions --json -n 5
 "${CXS_BIN:-cxs}" find "xsearch" --cwd /Users/me/work/foo --sort ended --exclude-session <current_uuid> --json -n 5
 ```
 
@@ -132,7 +135,7 @@ Example:
 
 ```bash
 "${CXS_BIN:-cxs}" list --selector '{"kind":"cwd_date_range","root":"/Users/me/.codex/sessions","cwd":"/Users/me/work/foo","fromDate":"2026-04-15","toDate":"2026-04-30"}' --sort ended --json
-"${CXS_BIN:-cxs}" list --root /Users/me/.codex/archived_sessions --sort ended --json
+"${CXS_BIN:-cxs}" list --root /Users/me/.codex/sessions --sort ended --json
 "${CXS_BIN:-cxs}" list --selector '{"kind":"cwd","cwd":"/Users/me/work/foo"}' --sort ended --json
 ```
 

--- a/skill-packages/cxs/references/failure-cookbook.md
+++ b/skill-packages/cxs/references/failure-cookbook.md
@@ -8,6 +8,7 @@
 | `sync` 非零退出带 per-file errors | `sync --root <dir> --json 2>&1` 或 `sync --selector '<json>' --json 2>&1` | 看 `errorDetails[]`；默认严格模式；只在允许部分成功时加 `--best-effort` |
 | `sync` 返回 `selector_required` | 原命令补 `--root`、`--cwd` 或 `--selector` | sync 必须显式给范围；不需要把 root 写进 JSON |
 | `find/list/stats/read-*` 输出 `index_unavailable` | `status --json` | 索引还没建立；选择范围后 `sync --root` / `sync --cwd` / `sync --selector` |
+| raw JSONL 从当前 source snapshot 中消失后担心查不到 | 直接 `find/list/read-*` 查 cxs index | cxs 默认保留已索引历史；不要引导用户改查另一个 root。只有用户明确要丢弃旧历史时才 `sync --prune` |
 | `stats/list/find` 报 `database is locked` | 原命令重试一次 | 多半是 SQLite 忙；仍失败就先跳过 `stats` 直接读 |
 | 同一主题多条 uuid | `find -n 10 --json` | 按 `startedAt`、`cwd`、`matchCount` 选 |
 | 最新/最近 + 关键词被当前会话抢结果 | `find <query> --sort ended --exclude-session <uuid>` | 默认 `find` 是 relevance 排序；时间问题显式用 `--sort ended` 并排除 self-hit |
@@ -44,6 +45,7 @@
 - 默认不要忽略，先看是坏 JSONL、权限问题还是别的解析失败。
 - 只有用户明确接受 partial index 时，才用 `--best-effort`。
 - `--best-effort` 不写 complete coverage。
+- 不要为普通历史查询加 `--prune`；它会删除所选 source 中已经消失的旧 index row。
 
 ## index_unavailable
 

--- a/skill-packages/cxs/references/progressive-workflow.md
+++ b/skill-packages/cxs/references/progressive-workflow.md
@@ -13,6 +13,8 @@
 
 - 没有 `sessionUuid` 时，不要冷启动 `read-page`
 - `sync` 只负责更新 index/coverage;查找不需要每次 sync
+- `sync` 默认保留已索引历史；raw JSONL 从 source snapshot 中消失后，不需要换 root 查询
+- 不要在日常查询前加 `--prune`;它只用于用户明确要求 cxs 丢弃 source 中已经消失的旧历史
 - 用户给了 `cwd` 或时间窗口:cwd/root 优先用 `--cwd` / `--root`;日期窗口用 selector JSON;先确认 coverage;缺失/stale 才同步;查询时继续带同一个范围
 - 用户问"最新/最近 + 关键词":不要用默认 `find` 当时间结论;用 `find <query> --sort ended`,并用 `--exclude-session <current_uuid>` 排除当前会话/self-hit
 - 已锁定 session 但锚点不对时，用 `read-range --query`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ program
   .option("--cwd <path>", "同步指定 cwd selector")
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--best-effort", "即使部分文件失败也继续写入可成功部分")
+  .option("--prune", "删除所选范围内已从 source 消失的旧索引行")
   .option("--json", "输出 JSON")
   .action(async (options) => {
     try {
@@ -82,6 +83,7 @@ program
         dbPath: options.db,
         selector,
         bestEffort: options.bestEffort,
+        prune: options.prune,
       });
       if (options.json) {
         console.log(JSON.stringify(summary, null, 2));

--- a/src/indexer.test.ts
+++ b/src/indexer.test.ts
@@ -116,7 +116,7 @@ describe("syncSessions", () => {
     });
   });
 
-  test("strict sync reconciles deleted source files before writing coverage", async () => {
+  test("strict sync retains indexed rows whose source files disappeared by default", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-indexer-reconcile-"));
     tempDirs.push(base);
     const root = join(base, "sessions");
@@ -146,6 +146,48 @@ describe("syncSessions", () => {
 
     rmSync(deletedPath);
     const summary = await syncSessions({ dbPath, selector });
+
+    expect(summary.removed).toBe(0);
+    expect(summary.coverage.sourceFileCount).toBe(1);
+    expect(summary.coverage.indexedSessionCount).toBe(2);
+
+    const found = findSessions(dbPath, "needle", 10, selector);
+    expect(found.results.map((result) => result.sessionUuid).sort()).toEqual([
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    ].sort());
+  });
+
+  test("sync --prune reconciles deleted source files before writing coverage", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-indexer-prune-"));
+    tempDirs.push(base);
+    const root = join(base, "sessions");
+    const day = join(root, "2026", "04", "22");
+    mkdirSync(day, { recursive: true });
+
+    const deletedPath = join(day, "rollout-2026-04-22T10-00-00-11111111-1111-4111-8111-111111111111.jsonl");
+    const keptPath = join(day, "rollout-2026-04-22T11-00-00-22222222-2222-4222-8222-222222222222.jsonl");
+    writeFileSync(
+      deletedPath,
+      [
+        line("session_meta", { id: "11111111-1111-4111-8111-111111111111", cwd: "/tmp/prune" }),
+        line("event_msg", { type: "user_message", message: "needle deleted" }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      keptPath,
+      [
+        line("session_meta", { id: "22222222-2222-4222-8222-222222222222", cwd: "/tmp/prune" }),
+        line("event_msg", { type: "user_message", message: "needle kept" }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const selector = { kind: "all" as const, root };
+    await syncSessions({ dbPath, selector });
+
+    rmSync(deletedPath);
+    const summary = await syncSessions({ dbPath, selector, prune: true });
 
     expect(summary.removed).toBe(1);
     expect(summary.coverage.sourceFileCount).toBe(1);

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -21,6 +21,7 @@ interface SyncOptions {
   rootDir?: string;
   selector?: Selector;
   bestEffort?: boolean;
+  prune?: boolean;
 }
 
 type SyncOperation =
@@ -111,6 +112,7 @@ export async function syncSessions(options: SyncOptions = {}): Promise<SyncSumma
         operations,
         summary,
         bestEffort,
+        Boolean(options.prune),
         selector,
         sourceSnapshot,
         retainedFilePaths,
@@ -199,6 +201,7 @@ function applyOperations(
   operations: SyncOperation[],
   summary: SyncSummary,
   bestEffort: boolean,
+  prune: boolean,
   selector: Selector,
   sourceSnapshot: { fingerprint: string; fileCount: number },
   retainedFilePaths: Set<string>,
@@ -223,7 +226,9 @@ function applyOperations(
       applyOperation(db, operation, selector.root);
     }
     cleanupMismatchedMessagesForSelector(db, selector);
-    summary.removed += deleteSessionsForSelectorExceptFilePaths(db, selector, retainedFilePaths);
+    if (prune) {
+      summary.removed += deleteSessionsForSelectorExceptFilePaths(db, selector, retainedFilePaths);
+    }
     const indexedSessionCount = countSessionsForSelector(db, selector);
     const record = replaceCoverage(
       db,


### PR DESCRIPTION
<!-- mainline:pr-description:start -->
## Mainline Intent

**Intent:** `int_e3a17375`
**Status:** `proposed`
**Title:** 默认保留已索引历史

### What changed

Changed cxs sync so missing raw source files are no longer treated as deletions by default. Added an explicit sync --prune option for callers that intentionally want to delete indexed rows that disappeared from the current source snapshot. Updated README, architecture/coverage docs, and the distributable cxs skill so agents query the SQLite index normally instead of switching to Codex-specific archive roots.

### Why

The user wanted Codex raw-log archival to be invisible to CXS users and agents. CXS should treat Codex JSONL files as ingest input, while the SQLite index remains the query surface for already indexed history.

### Decisions

- **Default strict sync behavior when a previously indexed source file is absent from the current source snapshot:** Retain the indexed session row and still write coverage for the current source snapshot. (This preserves historical query/read behavior after raw log maintenance and keeps Codex storage layout out of the cxs user workflow.)
  - Rejected: Keep pruning missing source files during every successful strict sync.
  - Rejected: Teach users or skills to query a separate Codex archive root.
- **How to support intentional cleanup of rows missing from source:** Add explicit sync --prune to run the old source-snapshot reconciliation deletion path. (Deletion remains available, but it is now an opt-in cleanup action rather than the normal incremental sync behavior.)
- **How to document Codex raw-log movement:** Describe raw JSONL as an ingest source and avoid archive-root examples in the skill package. (The agent-facing workflow should stay archive-agnostic and continue using find/list/read against the cxs index.)

**Subsystems:** sync, indexer, cli, docs, skill-packages, cxs retrieval
<!-- mainline:pr-description:end -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`sync` now keeps previously indexed sessions even if the raw JSONL disappears, so historical queries don’t vanish. Use `--prune` when you intentionally want to delete missing-source rows; docs and the cxs skill now steer queries to the SQLite index.

- **New Features**
  - Strict `sync` retains indexed rows that vanished from the current source snapshot and still writes complete coverage.
  - Added `--prune` to delete those rows on demand.
  - Updated CLI/docs/skill defaults to use `~/.codex/sessions`; version bump to `@act0r/cxs` `0.3.2`.

- **Migration**
  - If you relied on auto-pruning, run `sync --prune` for your selected scope.
  - Agents/users should keep querying the SQLite index; no need to switch Codex archive roots.

<sup>Written for commit 717d2c06e6314e2e65f1ab66add95cd731c4bf37. Summary will update on new commits. <a href="https://cubic.dev/pr/catoncat/cxs/pull/42?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

