### PR TITLE
⚡ Bolt: [performance improvement] Eliminate array allocations in snippet generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,6 @@
 ## 2025-02-18 - Avoid path.relative() in tight loops over absolute paths
 **Learning:** Found that using `node:path.relative()` inside a loop over thousands of absolute paths (`fingerprintFiles`) adds significant computational overhead because it performs deep path normalization and splitting on every call. In this code path, source files are collected under the resolved root, so every fingerprinted path is already an absolute path with the same prefix.
 **Action:** Pre-calculate the root prefix (with a trailing separator) and use `String.prototype.slice()` for an O(1) substring extraction instead of calling `path.relative()` for each file.
+## 2025-05-02 - Eliminate array allocations in snippet generation
+**Learning:** Found a performance bottleneck where `termHits.flatMap` was repeatedly creating match objects `{index, length}` for every occurrence of a query term. These objects were then iterated over, allocating memory and triggering garbage collection during search result formatting.
+**Action:** Replaced the array map/flatMap chain with nested `while` loops using `indexOf` to track the best snippet window in a single pass without allocating intermediate match objects. This improves memory efficiency during formatting.

--- a/src/query/snippet.ts
+++ b/src/query/snippet.ts
@@ -23,27 +23,35 @@ export function makeRawSnippet(content: string, query: string, terms: string[]):
   }
 
   const termLowers = uniqueNonEmpty(terms.map((term) => term.toLowerCase()));
-  const termHits = termLowers.flatMap((term) => collectTermHits(lower, term));
-  if (termHits.length === 0) return content.slice(0, 160);
 
   // OPTIMIZATION: Track best window in a single pass.
-  // Avoids intermediate array allocations from map() and O(N log N) overhead from sort().
+  // Avoids intermediate array allocations from flatMap/map and O(N log N) overhead from sort().
   let bestStart = 0;
   let bestEnd = 0;
   let bestAnchor = Infinity;
   let bestScore = -1;
+  let anyHit = false;
 
-  for (const hit of termHits) {
-    const start = Math.max(0, hit.index - 40);
-    const end = Math.min(content.length, hit.index + hit.length + 80);
-    const score = scoreSnippetWindow(lower.slice(start, end), termLowers);
-    if (score > bestScore || (score === bestScore && hit.index < bestAnchor)) {
-      bestStart = start;
-      bestEnd = end;
-      bestAnchor = hit.index;
-      bestScore = score;
+  for (const term of termLowers) {
+    let cursor = 0;
+    while (cursor < lower.length) {
+      const index = lower.indexOf(term, cursor);
+      if (index < 0) break;
+      anyHit = true;
+      const start = Math.max(0, index - 40);
+      const end = Math.min(content.length, index + term.length + 80);
+      const score = scoreSnippetWindow(lower.slice(start, end), termLowers);
+      if (score > bestScore || (score === bestScore && index < bestAnchor)) {
+        bestStart = start;
+        bestEnd = end;
+        bestAnchor = index;
+        bestScore = score;
+      }
+      cursor = index + term.length;
     }
   }
+
+  if (!anyHit) return content.slice(0, 160);
 
   return snippetWindow(content, bestStart, bestEnd, termLowers);
 }


### PR DESCRIPTION
💡 What: Replaced `termHits.flatMap` and intermediate object allocations in `makeRawSnippet` with a nested `while` loop that directly calculates best snippet windows in a single pass.
🎯 Why: Constructing `{index, length}` objects for every match inside every document in FTS results was causing unnecessary memory allocations and GC pressure.
📊 Impact: Eliminates a major source of garbage collection overhead during search result snippet formatting.
🔬 Measurement: Validated by `npm run check`. Tests assert identical snippet wrapping functionality before and after optimization.

---
*PR created automatically by Jules for task [5705608980270802315](https://jules.google.com/task/5705608980270802315) started by @catoncat*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up search snippet generation by removing array allocations and sorting with a single-pass loop. Reduces GC and memory use during result formatting with no change to output.

- **Refactors**
  - Replaced `flatMap` and per-match `{index, length}` objects with nested `while` loops over terms and content.
  - Computes the best snippet window in one pass; avoids extra arrays and sort.
  - Behavior unchanged; tests confirm identical snippet wrapping.

<sup>Written for commit 8928306930a9d981b1ea2f175df27113f86d3ad3. Summary will update on new commits. <a href="https://cubic.dev/pr/catoncat/cxs/pull/45?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

