### PR TITLE
Combined optimizations from #45, #46, and #48

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -200,8 +200,58 @@ function trimTranscriptMessage(text: string): string {
 }
 
 function trimText(text: string, limit: number): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  return normalized.length > limit ? `${normalized.slice(0, limit)}…` : normalized;
+  // OPTIMIZATION: Avoid expensive regex replace operations (text.replace(/\s+/g, " "))
+  // on large strings. Use a single-pass loop with charCodeAt to track spaces
+  // and truncate exactly when the limit is reached.
+  let res = "";
+  let inSpace = false;
+  const len = text.length;
+  let i = 0;
+
+  // Skip leading spaces
+  while (i < len && text.charCodeAt(i) <= 32) {
+    i++;
+  }
+
+  for (; i < len; i++) {
+    if (text.charCodeAt(i) <= 32) {
+      if (!inSpace) {
+        res += " ";
+        inSpace = true;
+      }
+    } else {
+      res += text[i];
+      inSpace = false;
+    }
+
+    if (res.length >= limit) {
+      // Check if remaining characters are all spaces
+      let hasMore = false;
+      for (let j = i + 1; j < len; j++) {
+        if (text.charCodeAt(j) > 32) {
+          hasMore = true;
+          break;
+        }
+      }
+      if (hasMore) {
+        if (res.endsWith(" ")) {
+          res = res.slice(0, -1);
+        }
+        res += "…";
+      } else {
+        if (res.endsWith(" ")) {
+          res = res.slice(0, -1);
+        }
+      }
+      break;
+    }
+  }
+
+  if (i === len && res.endsWith(" ")) {
+    res = res.slice(0, -1);
+  }
+
+  return res;
 }
 
 function stripMarks(snippet: string): string {

--- a/src/query/snippet.ts
+++ b/src/query/snippet.ts
@@ -23,27 +23,35 @@ export function makeRawSnippet(content: string, query: string, terms: string[]):
   }
 
   const termLowers = uniqueNonEmpty(terms.map((term) => term.toLowerCase()));
-  const termHits = termLowers.flatMap((term) => collectTermHits(lower, term));
-  if (termHits.length === 0) return content.slice(0, 160);
 
   // OPTIMIZATION: Track best window in a single pass.
-  // Avoids intermediate array allocations from map() and O(N log N) overhead from sort().
+  // Avoids intermediate array allocations from flatMap/map and O(N log N) overhead from sort().
   let bestStart = 0;
   let bestEnd = 0;
   let bestAnchor = Infinity;
   let bestScore = -1;
+  let anyHit = false;
 
-  for (const hit of termHits) {
-    const start = Math.max(0, hit.index - 40);
-    const end = Math.min(content.length, hit.index + hit.length + 80);
-    const score = scoreSnippetWindow(lower.slice(start, end), termLowers);
-    if (score > bestScore || (score === bestScore && hit.index < bestAnchor)) {
-      bestStart = start;
-      bestEnd = end;
-      bestAnchor = hit.index;
-      bestScore = score;
+  for (const term of termLowers) {
+    let cursor = 0;
+    while (cursor < lower.length) {
+      const index = lower.indexOf(term, cursor);
+      if (index < 0) break;
+      anyHit = true;
+      const start = Math.max(0, index - 40);
+      const end = Math.min(content.length, index + term.length + 80);
+      const score = scoreSnippetWindow(lower.slice(start, end), termLowers);
+      if (score > bestScore || (score === bestScore && index < bestAnchor)) {
+        bestStart = start;
+        bestEnd = end;
+        bestAnchor = index;
+        bestScore = score;
+      }
+      cursor = index + term.length;
     }
   }
+
+  if (!anyHit) return content.slice(0, 160);
 
   return snippetWindow(content, bestStart, bestEnd, termLowers);
 }

--- a/src/sources/codex-parser.ts
+++ b/src/sources/codex-parser.ts
@@ -174,10 +174,10 @@ function buildSessionSummary(messages: ParsedMessage[]): string {
   }
 
   const parts = [
-    firstUser ? `user: ${normalizeSummaryText(firstUser.contentText)}` : "",
-    firstAssistant ? `assistant: ${normalizeSummaryText(firstAssistant.contentText)}` : "",
-    latestUser && latestUser.seq !== firstUser?.seq ? `follow-up: ${normalizeSummaryText(latestUser.contentText)}` : "",
-    latestAssistant && latestAssistant.seq !== firstAssistant?.seq ? `latest: ${normalizeSummaryText(latestAssistant.contentText)}` : "",
+    firstUser ? `user: ${normalizeSummaryText(firstUser.contentText.slice(0, 5000))}` : "",
+    firstAssistant ? `assistant: ${normalizeSummaryText(firstAssistant.contentText.slice(0, 5000))}` : "",
+    latestUser && latestUser.seq !== firstUser?.seq ? `follow-up: ${normalizeSummaryText(latestUser.contentText.slice(0, 5000))}` : "",
+    latestAssistant && latestAssistant.seq !== firstAssistant?.seq ? `latest: ${normalizeSummaryText(latestAssistant.contentText.slice(0, 5000))}` : "",
   ].filter(Boolean);
 
   return parts.join(" | ").slice(0, 480);
@@ -195,7 +195,7 @@ function normalizeUniqueText(values: string[]): string {
   const seen = new Set<string>();
   const parts: string[] = [];
   for (const value of values) {
-    const normalized = normalizeSummaryText(value);
+    const normalized = normalizeSummaryText(value.slice(0, 5000));
     if (!normalized || seen.has(normalized)) continue;
     seen.add(normalized);
     parts.push(normalized);


### PR DESCRIPTION
This PR combines the optimizations from PR #45 (snippet generation), #46 (trimText regex optimization), and #48 (large string slicing for regex safety).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combines performance optimizations for snippet generation, text trimming, and codex summary parsing to cut allocations and avoid regex on large inputs. Snippet selection is faster and summaries are safer on very long messages.

- **Refactors**
  - `trimText`: replace `/\s+/g` with a single-pass whitespace coalescer; trims edges and adds an ellipsis only if more non-space text remains.
  - Snippet generation (`makeRawSnippet`): single-pass window scoring using `indexOf`; removes `flatMap`/sort; falls back to the first 160 chars when no term matches.
  - `codex-parser`: slice message texts to 5000 chars before `normalizeSummaryText` and de-dup; keeps summary cap; avoids regex over huge strings.

<sup>Written for commit 97b2d895180a932b60472e5494fdfcff8142e3ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/cxs/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

