### PR TITLE
feat(cli): 发布 Claude Code 实验性公开支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 progressive retrieval: find the right session first, then read only the relevant
 range or page.
 
-The only public session source in this checkout is `codex`. The CLI accepts
-`--source codex` on the fixed command set, and omitting `--source` means Codex.
-Claude Code has a private, non-public adapter path for synthetic verification
-and future promotion work; it is not a public CLI source and
-`--source claude-code` is rejected.
+The public session sources in this checkout are `codex` and experimental
+`claude-code`. The fixed command set accepts `--source <id>`, and omitting
+`--source` still means Codex. Claude Code support is public in this checkout,
+but it is still an experimental transcript-reader contract rather than a stable
+raw-format promise.
 
 When reading this from a source checkout, the installed `cxs` on your `PATH`
 may still be an older npm release. Check `cxs status --help` before using
@@ -104,7 +104,7 @@ npx @act0r/cxs@latest find "health check" --root /Users/you/.codex/sessions
 | Command | Purpose |
 | --- | --- |
 | `cxs status` | Show execution context, source inventory, index state, and coverage. `--selector` checks whether a target range is fresh. Does not write the index. |
-| `cxs sync --root <dir>\|--cwd <path>\|--selector <json>` | Scan selected Codex sessions and update the SQLite index. This is the only write command. |
+| `cxs sync --root <dir>\|--cwd <path>\|--selector <json>` | Scan selected sessions for the chosen source and update the SQLite index. This is the only write command. |
 | `cxs find <query>` | Search indexed sessions and return ranked session candidates with minimal snippets. Use `--root`, `--cwd`, and `--sort ended` for scoped "latest + keyword" queries. |
 | `cxs read-range <sessionUuid>` | Read a small message window around a matched sequence or in-session query. |
 | `cxs read-page <sessionUuid>` | Read a session page by offset and limit. |
@@ -114,20 +114,29 @@ npx @act0r/cxs@latest find "health check" --root /Users/you/.codex/sessions
 All commands that read indexed content support `--json`. Read commands fail
 cleanly if the index has not been created yet.
 
-In source-aware builds, all fixed commands accept `--source <id>`. The only
-public value is `codex`, so these are equivalent:
+In source-aware builds, all fixed commands accept `--source <id>`. Public
+values are `codex` and experimental `claude-code`; omitting `--source`
+defaults to Codex, so these are equivalent:
 
 ```bash
 cxs find "health check"
 cxs find "health check" --source codex
 ```
 
-Unknown sources and non-public sources such as `claude-code` return
-`unsupported_source` before doing command work. The private Claude Code adapter
-is available only to internal programmatic paths in this checkout and has been
-verified with synthetic fixtures, not real transcripts. If an installed CLI
-rejects the `--source` option itself, that installation predates this behavior;
-update the CLI or run the checkout with `npm run cxs -- ...`.
+Claude Code uses the same fixed command surface:
+
+```bash
+cxs status --source claude-code --json
+cxs sync --source claude-code --root ~/.claude/projects --json
+cxs find "health check" --source claude-code
+```
+
+Unknown sources still return `unsupported_source` before doing command work.
+Claude Code remains experimental public support: the current adapter is built
+around the existing local transcript reader, validated with synthetic fixtures,
+and may still evolve toward a more stable SDK/session API contract. If an
+installed CLI rejects the `--source` option itself, that installation predates
+this behavior; update the CLI or run the checkout with `npm run cxs -- ...`.
 
 ## Selectors
 
@@ -143,8 +152,8 @@ cxs list --root /Users/you/.codex/sessions --sort ended -n 10
 
 Use full selector JSON for date ranges or advanced scopes. If you pass
 `--root`, the selector JSON may omit `root`; without `--root`, cxs uses the
-default Codex sessions root. Selector JSON may also omit `source`; canonical
-selectors include `source: "codex"` in this checkout.
+default source root. Selector JSON may also omit `source`; canonical selectors
+include the resolved source id in this checkout.
 
 ```text
 {"source":"codex","kind":"all","root":"/Users/you/.codex/sessions"}
@@ -171,8 +180,9 @@ order.
 
 ## Sync And Storage
 
-By default, `cxs` reads Codex sessions from `~/.codex/sessions` and stores its
-index at:
+By default, `cxs` reads Codex sessions from `~/.codex/sessions`. With
+`--source claude-code`, the default root is `~/.claude/projects`. Index data is
+stored at:
 
 ```text
 ~/.local/state/cxs/index.sqlite

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 `status -> sync --root/--cwd/--selector -> message/session recall -> session heuristic rerank -> read-range/read-page`
 
-它已经可用，但仍是轻量 retrieval 后端，不是完整的 resource-level retrieval 系统。当前公开 session source 只有 `codex`；`claude-code` 已有 private / non-public adapter 路径用于 synthetic verification 和后续 promotion 工作，但没有公开 CLI 同步能力或发布承诺。
+它已经可用，但仍是轻量 retrieval 后端，不是完整的 resource-level retrieval 系统。当前公开 session source 有 `codex` 和 experimental `claude-code`；其中 `claude-code` 已接到固定 CLI 命令面，但仍应视作 experimental transcript-reader support，而不是稳定 raw-format 承诺。
 
 ## 当前命令面
 
@@ -20,18 +20,18 @@
 
 这套命令面已经定型，不再保留 `window/session` 旧别名语义。
 
-这些命令都接受可省略的 `--source <id>`。当前唯一公开值是 `codex`，省略时等价于 `--source codex`。传入未知 source 或非公开 `claude-code` 会返回 `unsupported_source`，不会开始扫描、查询或读取。
+这些命令都接受可省略的 `--source <id>`。当前公开值是 `codex` 和 experimental `claude-code`，省略时等价于 `--source codex`。传入未知 source 会返回 `unsupported_source`，不会开始扫描、查询或读取。
 
 ## 数据流
 
 ### 0. Source adapter
 
-`src/sources/` 定义 source adapter 边界和 registry。当前 registry 公开 Codex adapter，并保留一个非公开 Claude Code adapter：
+`src/sources/` 定义 source adapter 边界和 registry。当前 registry 公开 Codex adapter 和 experimental Claude Code adapter：
 
 - `codex` adapter 负责默认 root、Codex JSONL inventory/snapshot、Codex parser。
-- `claude-code` adapter 是 private / non-public：它只允许内部 programmatic verification，通过 synthetic JSONL 证明 source-aware indexing / read isolation，不接受 public CLI `--source claude-code`。
+- `claude-code` adapter 负责默认 root、Claude Code transcript inventory/snapshot、Claude parser，并通过 public fixed-command surface 接入 source-aware indexing / read isolation。
 - 核心层负责 selector、coverage、DB、query/read/list/stats。
-- 公开命令面仍只有 `codex` source；未知 source 或非公开 `claude-code` 会在 CLI 边界返回 `unsupported_source`。
+- 公开命令面默认仍是 `codex` source；切换 `--source claude-code` 时走同一组命令，但当前语义仍限于 allowlisted transcript text。
 
 Codex adapter 会把原有 `sessionUuid` 映射为 source-aware identity：
 
@@ -45,7 +45,7 @@ Codex adapter 会把原有 `sessionUuid` 映射为 source-aware identity：
 
 [status.ts](/Users/envvar/work/repos/cxs/src/status.ts) 返回执行上下文、source inventory、index 状态与 coverage 状态。它可以扫描 raw sessions 的 metadata，但不回答内容问题。
 
-[indexer.ts](/Users/envvar/work/repos/cxs/src/indexer.ts) 按显式 selector 扫描选定 source 的 session snapshot。当前公开 source 只有 Codex，因此实际扫描的是 Codex JSONL sessions；增量判断仍基于文件 `mtime`、`size` 和 `indexVersion`。
+[indexer.ts](/Users/envvar/work/repos/cxs/src/indexer.ts) 按显式 selector 扫描选定 source 的 session snapshot。当前公开 source 可以是 Codex 或 Claude Code；增量判断仍基于文件 `mtime`、`size` 和 `indexVersion`。
 
 strict sync 默认只更新当前 source snapshot 中仍可见的文件，并保留已经进入 SQLite 的旧 session。这样 raw JSONL 的维护、移动或删除不会让 cxs 的历史查询丢失。只有显式传 `--prune` 时，sync 才会把 selector 范围收敛成当前 source snapshot，并删除同一 source 中已不存在的旧 index row。一个 source 的 sync/prune 不会删除另一个 source 的数据。当前 source 中仍存在但被过滤或不能解析成 session 的文件仍按当前状态处理。
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 `cxs` 现在已经有一条可用的 retrieval 主链。`title + summary_text + compact_text + reasoning_summary_text` 已作为 session-level recall 面接入，并通过 FTS5 column weights 显式分权；下一步仍不该盲目继续堆排序逻辑，当前最缺的是更可信的 acceptance gate。
 
-当前 source foundation 已落地到 checkout：公开 CLI source 只有 `codex`，`--source codex` 可省略，selector / coverage / DB / query-read 已有 source 维度。`claude-code` 已有 private/non-public adapter 路径，并通过 synthetic programmatic sync/read smoke 验证；但它仍不能写成已发布、已安装或 public CLI 可同步能力。
+当前 source foundation 已落地到 checkout：公开 CLI source 现在有 `codex` 和 experimental `claude-code`，省略 `--source` 仍等价于 `codex`，selector / coverage / DB / query-read 已有 source 维度。`claude-code` 现在已经走通 public fixed-command surface，但仍应描述为 experimental transcript-reader support，而不是稳定 raw-format 承诺。
 
 ## 优先级
 
@@ -30,7 +30,7 @@
 建议动作：
 
 - 扩充真实 query 集
-- 给 source-aware 默认行为补 acceptance：省略 source 等价于 `codex`、selector canonical JSON 带 `source: "codex"`、coverage 不跨 source、非公开 `claude-code` 返回 `unsupported_source`
+- 给 source-aware 默认行为补 acceptance：省略 source 等价于 `codex`、selector canonical JSON 带显式 `source`、coverage 不跨 source、`claude-code` 的 fixed-command public smoke 持续通过、未知 source 仍返回 `unsupported_source`
 - 继续用 dev-only `~/.agents/skills/cxs-dogfood` 手动策展本机 dogfood golden；不要把私有样本放进发行 skill package
 - 增加更强断言：
   - session 是否对
@@ -89,12 +89,12 @@
 
 这些都应该建立在更强 eval 之后，而不是先上。
 
-### Deferred: Claude Code public adapter
+### Deferred: Claude Code public support hardening
 
-未来如果要公开 Claude Code source，需要单独设计和验收：
+Claude Code 现在已经有 experimental public support，后续重点从“能不能公开”转成“怎么把公开契约做稳”：
 
-- 从当前 private/non-public adapter 出发，重新确认 public surface 和 release wording。
-- 优先重新评估官方 SDK/session API，而不是直接承诺 raw JSONL。
+- 重新评估官方 SDK/session API，判断是否要继续长期承诺当前 transcript reader。
 - 明确 tool results、attachments、diagnostics、snapshots、hook payloads、thinking、sidechain/subagent 语义。
-- 增加 source-specific privacy tests 和 public docs review。
-- 只有实现、测试、release docs 和 skill 都完成后，才能把 `claude-code` 从 reserved/non-public 提升为 public source。
+- 增加更强的 source-specific privacy tests 和 recall/eval 覆盖。
+- 补 release docs、installed CLI smoke、global skill update readback。
+- 如果后续发现 raw transcript contract 漂移，优先收敛 parser/SDK strategy，不要直接扩大 public 承诺。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@act0r/cxs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@act0r/cxs",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@act0r/cxs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
-  "description": "Progressive search CLI for local Codex session logs",
+  "description": "Progressive search CLI for local Codex and Claude Code session logs",
   "license": "MIT",
   "homepage": "https://github.com/catoncat/cxs",
   "repository": {
@@ -25,6 +25,7 @@
   },
   "keywords": [
     "codex",
+    "claude-code",
     "cli",
     "fts",
     "search",

--- a/skill-packages/cxs/SKILL.md
+++ b/skill-packages/cxs/SKILL.md
@@ -5,7 +5,7 @@ description: "Use proactively for local Codex history and personal setup archaeo
 
 # cxs
 
-用 `cxs` 在自己的 SQLite index 里检索旧 Codex 对话。当前公开 CLI source 只有 `codex`；`--source codex` 可省略。`claude-code` 在源码 checkout 里已有 private/non-public adapter path,仅用于 synthetic verification 和后续 promotion 候选；不要把它说成已发布、已安装、public CLI 可同步或正常可查询。Codex 的 raw sessions 只是 ingest source；正常历史检索只读 cxs index,不要让用户切换 source root 去追 raw 文件位置。心法:**先选 retrieval primitive,再定位候选 session,最后用 cxs read 命令拿内容证据**。
+用 `cxs` 在自己的 SQLite index 里检索旧 agent 对话。当前公开 CLI source 有 `codex` 和 experimental `claude-code`；省略 `--source` 仍等价于 `--source codex`。`claude-code` 现在是 public fixed-command support，但仍是 experimental transcript-reader contract；不要把它说成稳定 raw JSONL 承诺，遇到非 text record 语义缺口也不要跳回 raw source root 取证。各 source 的 raw sessions 都只是 ingest source；正常历史检索只读 cxs index。心法:**先选 retrieval primitive,再定位候选 session,最后用 cxs read 命令拿内容证据**。
 
 ## 安装(两步)
 
@@ -16,7 +16,7 @@ description: "Use proactively for local Codex history and personal setup archaeo
 ```bash
 "${CXS_BIN:-cxs}" --version       # 应输出 cxs 版本号
 "${CXS_BIN:-cxs}" --help          # 应列出 status/sync/find/read-range/read-page/list/stats
-"${CXS_BIN:-cxs}" status --help   # 若显示 --source <id>, public source 只有 codex
+"${CXS_BIN:-cxs}" status --help   # 若显示 --source <id>,应列出 codex|claude-code
 ```
 
 如果 `cxs` 不在 PATH 里,设 `export CXS_BIN=/absolute/path/to/bin/cxs`。如果安装版
@@ -46,7 +46,7 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 | coverage/freshness/index availability: 索引缺失、coverage stale、要决定是否同步 | `cxs status --json` / `status --cwd` / `status --selector` | `status` 不回答内容问题,只决定 coverage 和 sync 需求 |
 | mutation: 建索引或更新 coverage | `cxs sync --cwd/--root/--selector` | 普通检索不要 `--prune`;只有用户明确要求清理已消失 source 的旧索引记录才用 |
 
-在支持 source-aware CLI 的版本里,所有固定命令都可带 `--source <id>`；当前 public CLI 只用 `codex`，省略等价于 `--source codex`。遇到 `unsupported_source`，不要改用 raw source root，也不要声称 Claude Code 支持已发布。源码 checkout 里的 private `claude-code` path 不是 public CLI 承诺,只说明内部 synthetic verification 已有候选实现。如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
+在支持 source-aware CLI 的版本里,所有固定命令都可带 `--source <id>`；当前 public CLI 支持 `codex` 和 experimental `claude-code`，省略等价于 `--source codex`。遇到 `unsupported_source`，说明 source id 未知，不要改用 raw source root。Claude Code 支持已公开，但仍是 experimental transcript-reader support；如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
 
 `find` / `list` 返回零结果不是结束条件。遇到零结果、用户说“应该有”、问题涉及最近/当前 repo、或 JSON 里有 `nextAction` 时,必须先按同一范围做 coverage check:
 

--- a/skill-packages/cxs/references/cli-surface.md
+++ b/skill-packages/cxs/references/cli-surface.md
@@ -16,7 +16,7 @@ export CXS_BIN=/absolute/path/to/bin/cxs
 
 metadata-only 问题可以直接对 cxs SQLite index 做只读 projection,例如时间排序、数量、cwd 分布；内容判断仍必须回到 `read-page` / `read-range`。
 
-支持 source-aware CLI 的版本里,所有固定命令都接受 `--source <id>`。当前公开 source 只有 `codex`，省略等价于 `--source codex`。未知 source 或非公开 `claude-code` 会返回 `unsupported_source`，不要把它当成 public CLI 可用 adapter。当前源码 checkout 有 private/non-public Claude Code adapter path,只用于 synthetic programmatic verification 和未来 promotion 候选；它不代表已发布、已安装、可同步真实 Claude transcript,也不是稳定 public raw JSONL 格式决定。如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
+支持 source-aware CLI 的版本里,所有固定命令都接受 `--source <id>`。当前公开 source 是 `codex` 和 experimental `claude-code`，省略等价于 `--source codex`。未知 source 会返回 `unsupported_source`。Claude Code 已是 public CLI 可用 adapter，但仍是 experimental transcript-reader support；不要把它理解成稳定 raw transcript 格式承诺。如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
 
 缺少 cxs 索引时,`find` / `read-range` / `read-page` / `list` / `stats --json` 返回:
 
@@ -40,7 +40,7 @@ Example:
 "${CXS_BIN:-cxs}" status --root /Users/me/.codex/sessions --selector '{"kind":"all"}' --json
 ```
 
-常用 options: `--source <id>`(public: `codex`)、`--root`、`--selector`、`--cwd`、`--db`、`--json`。
+常用 options: `--source <id>`(public: `codex|claude-code`)、`--root`、`--selector`、`--cwd`、`--db`、`--json`。
 
 `status --selector` 是只读 coverage check。看 `requestedCoverage`:
 
@@ -67,7 +67,7 @@ Options:
 
 | option | 说明 |
 | --- | --- |
-| `--source <id>` | 当前唯一公开值是 `codex`;省略等价于 `codex` |
+| `--source <id>` | 公开值是 `codex` 和 experimental `claude-code`;省略等价于 `codex` |
 | `--root <dir>` | 同步整个 sessions 根目录；也作为 selector 默认 root |
 | `--cwd <path>` | 同步指定 cwd selector；不必手写 selector JSON |
 | `--selector <json>` | 结构化同步范围；日期范围等高级范围用这个 |
@@ -111,7 +111,7 @@ Options:
 
 | option | 说明 |
 | --- | --- |
-| `--source <id>` | 当前唯一公开值是 `codex`;省略等价于 `codex` |
+| `--source <id>` | 公开值是 `codex` 和 experimental `claude-code`;省略等价于 `codex` |
 | `--root <dir>` | 限定到整个 sessions 根目录；也作为 selector 默认 root |
 | `--cwd <path>` | 限定到指定 cwd selector |
 | `--selector <json>` | 结构化查询范围；可省略 `root` |
@@ -127,7 +127,7 @@ Notes:
 
 - 必须显式传 `<sessionUuid>`
 - 必须二选一提供 `--seq` 或 `--query`
-- 可选 `--source codex`;省略等价于 Codex。`codex:<uuid>` qualifier 只在 source 匹配时有效。
+- 可选 `--source codex|claude-code`;省略等价于 Codex。`<source>:<uuid>` qualifier 只在 source 匹配时有效。
 
 Example:
 
@@ -140,7 +140,7 @@ Example:
 
 Purpose: 顺序分页读取某个 session 的消息。metadata projection 只能给候选;要确认"当时说了什么/是否有意义",用 `read-page` 或 `read-range`。
 
-可选 `--source codex`;省略等价于 Codex。
+可选 `--source codex|claude-code`;省略等价于 Codex。
 
 Example:
 
@@ -152,7 +152,7 @@ Example:
 
 Purpose: 列出已索引 session，不做全文检索。适合简单 session listing；更复杂的 metadata projection 可以用只读 SQLite 查询 cxs index。
 
-常用 options: `--source <id>`(public: `codex`)、`--cwd`、`--since`、`--root`、`--selector`、`--sort ended|started|messages`、`-n/--limit`、`--db`、`--json`。
+常用 options: `--source <id>`(public: `codex|claude-code`)、`--cwd`、`--since`、`--root`、`--selector`、`--sort ended|started|messages`、`-n/--limit`、`--db`、`--json`。
 
 Example:
 
@@ -166,7 +166,7 @@ Example:
 
 Purpose: 展示索引状态统计。
 
-可选 `--source codex`;省略等价于 Codex。
+可选 `--source codex|claude-code`;省略等价于 Codex。
 
 Example:
 

--- a/skill-packages/cxs/references/failure-cookbook.md
+++ b/skill-packages/cxs/references/failure-cookbook.md
@@ -18,7 +18,7 @@
 | 用户问“最近本项目讨论了什么” | `list --cwd <abs_cwd> --sort ended --json` | 这是 metadata/listing 问题；索引不可用或 coverage 不明时再 `status --cwd` |
 | 用户说“在 X 项目里” | `status --json` | 从 `sourceInventory.cwdGroups` 选择 cwd selector |
 | 从其他 cwd 调用找不到 db | `stats --json` | 看 `dbPath`；必要时显式传 `--db` |
-| `unsupported_source` | 改回省略 `--source` 或 `--source codex` | 当前只有 Codex 是 public source；即使源码 checkout 有 private Claude Code adapter path,也不要改查 Claude Code raw files 或说 public CLI 已支持 |
+| `unsupported_source` | 检查 source id 拼写，必要时改回省略 `--source`、`--source codex` 或 `--source claude-code` | 当前公开 source 是 `codex` 和 experimental `claude-code`；不要因为 source id 写错就跳回 raw source root |
 
 ## Find zero results but user insists it exists
 
@@ -176,7 +176,7 @@ sqlite3 -readonly "$DB_PATH" \
 | `status` invalid selector | stdout | `{ "error": { "code": "invalid_selector", "message": "..." } }` |
 | `find / read-range / read-page / list / stats` 索引不存在 | stdout | `{ "error": { "code": "index_unavailable", "message": "...", "dbPath": "...", "hint": "..." } }` |
 | `find / read-range / read-page / list / stats` 旧 index schema | stdout | `{ "error": { "code": "index_schema_upgrade_required", "message": "...", "dbPath": "...", "missingColumns": ["..."], "hint": "..." } }` |
-| 任意命令传非公开 source | stdout | `{ "error": { "code": "unsupported_source", "source": "...", "message": "Only \"codex\" is public in this release." } }` |
+| 任意命令传未知 source | stdout | `{ "error": { "code": "unsupported_source", "source": "...", "message": "Public sources in this release: codex|claude-code." } }` |
 | `find / read-range / read-page / list / stats` 其他异常 | 进程异常退出 | 直接非零退出 |
 
 ## Schema drift

--- a/skill-packages/cxs/references/json-schema.md
+++ b/skill-packages/cxs/references/json-schema.md
@@ -89,7 +89,7 @@ Treat it as a retry gate: choose/check the same selector, run `sync` only if `st
 ```ts
 {
   query: {
-    sourceId?: "codex";
+    sourceId?: "codex" | "claude-code";
     cwd?: string;
     since?: string;
     selector?: Selector;
@@ -191,7 +191,7 @@ errors in `--json` mode for expected index setup failures:
 ```ts
 {
   id: number;
-  sourceId: "codex";
+  sourceId: "codex" | "claude-code";
   nativeSessionId: string;
   sessionKey: string;
   sessionUuid: string;
@@ -225,13 +225,13 @@ errors in `--json` mode for expected index setup failures:
 
 ```ts
 type Selector =
-  | { source?: "codex"; kind: "all"; root: string }
-  | { source?: "codex"; kind: "date_range"; root: string; fromDate: string; toDate: string }
-  | { source?: "codex"; kind: "cwd"; root: string; cwd: string }
-  | { source?: "codex"; kind: "cwd_date_range"; root: string; cwd: string; fromDate: string; toDate: string };
+  | { source?: "codex" | "claude-code"; kind: "all"; root: string }
+  | { source?: "codex" | "claude-code"; kind: "date_range"; root: string; fromDate: string; toDate: string }
+  | { source?: "codex" | "claude-code"; kind: "cwd"; root: string; cwd: string }
+  | { source?: "codex" | "claude-code"; kind: "cwd_date_range"; root: string; cwd: string; fromDate: string; toDate: string };
 ```
 
-Input selector JSON may omit `source`; canonical selectors returned by public CLI commands include `source: "codex"`. `claude-code` is private/non-public and rejected at the CLI boundary with `unsupported_source`. A source checkout may have an internal synthetic-verification adapter path for `claude-code`, but these public CLI schemas should not be read as a release, install, or stable raw-format promise.
+Input selector JSON may omit `source`; canonical selectors returned by public CLI commands include the resolved source id. `claude-code` is now a public but experimental CLI source. These public CLI schemas still should not be read as a stable raw-format promise; Claude support may move toward a different SDK/session contract in later releases.
 
 `CoverageStatus`:
 

--- a/skill-packages/cxs/references/progressive-workflow.md
+++ b/skill-packages/cxs/references/progressive-workflow.md
@@ -19,7 +19,7 @@ Hard rules:
 - Do not use `sync --prune` for normal retrieval.
 - `find` default sort is relevance; use `--sort ended` only when the user's question is time-oriented.
 - `matchSource = "session"` means `matchSeq = null`; use `read-page` instead of inventing a seq.
-- Current public source is only `codex`; omit `--source` or pass `--source codex`. Do not claim published, installed, or public CLI Claude Code source support. A checkout may contain a private/non-public `claude-code` adapter path for synthetic verification, but that is not normal retrieval guidance and not a public raw-format promise.
+- Current public sources are `codex` and experimental `claude-code`; omit `--source` or pass `--source codex` for the default. Claude Code is part of the normal CLI surface now, but it is still not a stable raw-format promise.
 
 ## Scenario 1: Metadata Projection
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -320,12 +320,11 @@ describe("cxs cli", () => {
     expect(payload.error.message).toContain("--selector");
   });
 
-  test("fixed commands reject unsupported and non-public --source values before other work", async () => {
+  test("fixed commands reject unsupported --source values before other work", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-cli-source-unsupported-"));
     tempDirs.push(base);
     const dbPath = join(base, "missing.sqlite");
     const commands = [
-      ["status", "--source", "claude-code", "--db", dbPath, "--json"],
       ["sync", "--source", "other", "--root", join(base, "sessions"), "--db", dbPath, "--json"],
       ["find", "needle", "--source", "other", "--db", dbPath, "--json"],
       ["read-range", "14141414-1414-4414-8414-141414141414", "--source", "other", "--db", dbPath, "--json"],
@@ -339,23 +338,126 @@ describe("cxs cli", () => {
       expect(result.exitCode).toBe(1);
       const payload = JSON.parse(result.stdout) as { error: { code: string; source: string; message: string } };
       expect(payload.error.code).toBe("unsupported_source");
-      expect(payload.error.message).toContain("Only \"codex\" is public");
+      expect(payload.error.message).toContain("unsupported source");
       expect(result.stderr).toBe("");
     }
   });
 
-  test("selector JSON source is rejected when it is not public Codex", async () => {
+  test("selector JSON source is rejected when it is unsupported", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-cli-selector-source-unsupported-"));
     tempDirs.push(base);
-    const selector = JSON.stringify({ source: "claude-code", kind: "all", root: join(base, "sessions") });
+    const selector = JSON.stringify({ source: "other", kind: "all", root: join(base, "sessions") });
 
     const result = await runCli(["sync", "--selector", selector, "--db", join(base, "index.sqlite"), "--json"]);
 
     expect(result.exitCode).toBe(1);
     const payload = JSON.parse(result.stdout) as { error: { code: string; source: string; message: string } };
     expect(payload.error.code).toBe("unsupported_source");
-    expect(payload.error.source).toBe("claude-code");
-    expect(payload.error.message).toContain("Only \"codex\" is public");
+    expect(payload.error.source).toBe("other");
+    expect(payload.error.message).toContain("unsupported source");
+  });
+
+  test("fixed commands accept explicit --source claude-code", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-source-claude-code-"));
+    tempDirs.push(base);
+    const root = join(base, "projects");
+    mkdirSync(root, { recursive: true });
+    const projectDir = join(root, "synthetic-project");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, "conversation.jsonl"),
+      [
+        claudeLine({
+          type: "user",
+          sessionId: "cli-claude-session",
+          cwd: "/tmp/source-claude",
+          timestamp: "2026-06-06T00:00:00.000Z",
+          message: { content: "source claude needle" },
+        }),
+        claudeLine({
+          type: "assistant",
+          sessionId: "cli-claude-session",
+          cwd: "/tmp/source-claude",
+          timestamp: "2026-06-06T00:00:01.000Z",
+          message: { content: "source claude reply" },
+        }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const synced = await runCli(["sync", "--source", "claude-code", "--root", root, "--db", dbPath, "--json"]);
+    expect(synced.exitCode).toBe(0);
+    const syncPayload = JSON.parse(synced.stdout) as { coverage: { selector: { source: string; kind: string; root: string } } };
+    expect(syncPayload.coverage.selector).toEqual({ source: "claude-code", kind: "all", root });
+
+    const status = await runCli(["status", "--source", "claude-code", "--root", root, "--db", dbPath, "--json"]);
+    expect(status.exitCode).toBe(0);
+    const statusPayload = JSON.parse(status.stdout) as {
+      context: { root: string };
+      sourceInventory: { totalFiles: number };
+      coverage: Array<{ selector: { source: string } }>;
+    };
+    expect(statusPayload.context.root).toBe(root);
+    expect(statusPayload.sourceInventory.totalFiles).toBe(1);
+    expect(statusPayload.coverage[0]?.selector.source).toBe("claude-code");
+
+    const found = await runCli(["find", "source claude needle", "--source", "claude-code", "--db", dbPath, "--json"]);
+    expect(found.exitCode).toBe(0);
+    const findPayload = JSON.parse(found.stdout) as { results: Array<{ sessionUuid: string; cwd: string }> };
+    expect(findPayload.results[0]?.sessionUuid).toBe("claude-code:cli-claude-session");
+    expect(findPayload.results[0]?.cwd).toBe("/tmp/source-claude");
+
+    const listed = await runCli(["list", "--source", "claude-code", "--db", dbPath, "--json"]);
+    expect(listed.exitCode).toBe(0);
+    const listPayload = JSON.parse(listed.stdout) as { query: { sourceId?: string }; results: Array<{ sessionUuid: string }> };
+    expect(listPayload.query.sourceId).toBe("claude-code");
+    expect(listPayload.results[0]?.sessionUuid).toBe("claude-code:cli-claude-session");
+
+    const stats = await runCli(["stats", "--source", "claude-code", "--db", dbPath, "--json"]);
+    expect(stats.exitCode).toBe(0);
+    const statsPayload = JSON.parse(stats.stdout) as { sessionCount: number; messageCount: number };
+    expect(statsPayload.sessionCount).toBe(1);
+    expect(statsPayload.messageCount).toBe(2);
+
+    const range = await runCli([
+      "read-range",
+      "cli-claude-session",
+      "--source",
+      "claude-code",
+      "--seq",
+      "0",
+      "--before",
+      "0",
+      "--after",
+      "0",
+      "--db",
+      dbPath,
+      "--json",
+    ]);
+    expect(range.exitCode).toBe(0);
+    const rangePayload = JSON.parse(range.stdout) as {
+      session: { sourceId: string; sessionUuid: string };
+      messages: Array<{ contentText: string }>;
+    };
+    expect(rangePayload.session.sourceId).toBe("claude-code");
+    expect(rangePayload.session.sessionUuid).toBe("claude-code:cli-claude-session");
+    expect(rangePayload.messages[0]?.contentText).toBe("source claude needle");
+
+    const page = await runCli([
+      "read-page",
+      "cli-claude-session",
+      "--source",
+      "claude-code",
+      "--limit",
+      "1",
+      "--db",
+      dbPath,
+      "--json",
+    ]);
+    expect(page.exitCode).toBe(0);
+    const pagePayload = JSON.parse(page.stdout) as { session: { sourceId: string }; totalCount: number };
+    expect(pagePayload.session.sourceId).toBe("claude-code");
+    expect(pagePayload.totalCount).toBe(2);
   });
 
   test("sync with cwd selector writes coverage and find stays scoped", async () => {
@@ -1071,4 +1173,8 @@ async function runExecutable(
       resolve({ exitCode: code ?? 0, stdout, stderr });
     });
   });
+}
+
+function claudeLine(record: Record<string, unknown>): string {
+  return JSON.stringify(record);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import {
   statsReadoutEnabled,
 } from "./env";
 import { IndexSchemaUpgradeRequiredError, IndexUnavailableError } from "./db";
-import { getSessionSourceAdapter } from "./sources";
+import { getSessionSourceAdapter, listSessionSourceAdapters } from "./sources";
 
 // One-shot migration from legacy ~/.cache/cxs/ to ~/.local/state/cxs/. Runs
 // before any subcommand so `cxs stats` etc. see the migrated db, not just
@@ -45,7 +45,7 @@ program
 program
   .command("status")
   .description("返回执行上下文、source inventory、index 与 coverage 状态")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("--root <dir>", "覆盖默认 sessions 根目录，也作为 selector 默认 root")
   .option("--selector <json>", "检查指定 selector 的 coverage/freshness（只读，不同步）")
   .option("--cwd <path>", "检查指定 cwd selector 的 coverage/freshness")
@@ -77,7 +77,7 @@ program
 program
   .command("sync")
   .description("扫描并同步本地 Codex sessions 到 SQLite 索引")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("--root <dir>", "同步指定 sessions 根目录；也作为 selector 默认 root")
   .option("--selector <json>", "结构化同步范围 JSON")
   .option("--cwd <path>", "同步指定 cwd selector")
@@ -135,7 +135,7 @@ program
 program
   .command("find <query>")
   .description("搜索相关 session，返回最小必要命中")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("-n, --limit <n>", "返回条数", "10")
   .option("--root <dir>", "限定到指定 sessions 根目录；也作为 selector 默认 root")
   .option("--selector <json>", "结构化查询范围 JSON")
@@ -169,7 +169,7 @@ program
 program
   .command("read-range <sessionUuid>")
   .description("围绕命中点读取局部上下文；必须显式传 session_uuid")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("--seq <n>", "显式指定锚点 seq")
   .option("--query <query>", "用 query 在该 session 内重新定位命中点")
   .option("--before <n>", "前文条数", "2")
@@ -205,7 +205,7 @@ program
 program
   .command("read-page <sessionUuid>")
   .description("顺序分页读取某个 session 的消息")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("--offset <n>", "起始 offset", "0")
   .option("--limit <n>", "页大小", "20")
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
@@ -240,7 +240,7 @@ program
 program
   .command("list")
   .description("列出已索引的 session（不做全文检索）")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("--cwd <needle>", "cwd 子串过滤（大小写不敏感）")
   .option("--since <iso>", "只看 ended_at >= 指定时间的 session")
   .option("--root <dir>", "限定到指定 sessions 根目录；也作为 selector 默认 root")
@@ -273,7 +273,7 @@ program
 program
   .command("stats")
   .description("展示索引状态统计")
-  .option("--source <id>", "session source (public: codex)")
+  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--json", "输出 JSON")
   .action((options) => {
@@ -346,7 +346,7 @@ class SourceOptionError extends Error {
   sourceId: string;
 
   constructor(sourceId: string) {
-    super(`unsupported source "${sourceId}". Only "codex" is public in this release.`);
+    super(`unsupported source "${sourceId}". Public sources in this release: ${publicSourceLabel()}.`);
     this.name = "SourceOptionError";
     this.sourceId = sourceId;
   }
@@ -354,8 +354,28 @@ class SourceOptionError extends Error {
 
 function publicSource(value: string | undefined): SessionSourceId {
   const sourceId = (value ?? "codex").trim();
-  if (sourceId === "codex") return "codex";
+  const adapter = resolvePublicSourceAdapter(sourceId);
+  if (adapter) return adapter.id;
   throw new SourceOptionError(sourceId || "(empty)");
+}
+
+function publicSourceLabel(): string {
+  return getPublicSourceAdapters()
+    .map((adapter) => adapter.id)
+    .join("|");
+}
+
+function resolvePublicSourceAdapter(sourceId: string) {
+  try {
+    const adapter = getSessionSourceAdapter(sourceId as SessionSourceId);
+    return adapter.public ? adapter : null;
+  } catch {
+    return null;
+  }
+}
+
+function getPublicSourceAdapters() {
+  return listSessionSourceAdapters().filter((adapter) => adapter.public);
 }
 
 function emitSourceError(error: SourceOptionError, jsonMode: boolean): void {

--- a/src/sources/claude-code.test.ts
+++ b/src/sources/claude-code.test.ts
@@ -16,13 +16,16 @@ afterEach(() => {
 });
 
 describe("claude-code source adapter", () => {
-  test("is registered as a private non-public adapter", () => {
+  test("is registered as a public adapter", () => {
     const adapter = getSessionSourceAdapter("claude-code");
 
     expect(adapter.id).toBe("claude-code");
-    expect(adapter.public).toBe(false);
+    expect(adapter.public).toBe(true);
     expect(listSessionSourceAdapters().map((source) => source.id)).toEqual(["codex", "claude-code"]);
-    expect(listSessionSourceAdapters().filter((source) => source.public).map((source) => source.id)).toEqual(["codex"]);
+    expect(listSessionSourceAdapters().filter((source) => source.public).map((source) => source.id)).toEqual([
+      "codex",
+      "claude-code",
+    ]);
   });
 
   test("rejects an explicit selector source mismatch before syncing or writing coverage", async () => {
@@ -326,9 +329,12 @@ describe("claude-code source adapter", () => {
     expect(foundBeta.results[0]?.sessionUuid).toMatch(/^claude-code:conversation-[0-9a-f]{64}$/);
   });
 
-  test("keeps current-main Codex adapter as the only public adapter", () => {
+  test("keeps Codex as the default adapter while Claude Code is also public", () => {
     expect(getSessionSourceAdapter().id).toBe("codex");
-    expect(listSessionSourceAdapters().filter((adapter) => adapter.public).map((adapter) => adapter.id)).toEqual(["codex"]);
+    expect(listSessionSourceAdapters().filter((adapter) => adapter.public).map((adapter) => adapter.id)).toEqual([
+      "codex",
+      "claude-code",
+    ]);
   });
 });
 

--- a/src/sources/claude-code.ts
+++ b/src/sources/claude-code.ts
@@ -5,7 +5,7 @@ import type { SessionSourceAdapter, SourceSnapshotOptions } from "./types";
 
 export const claudeCodeSourceAdapter: SessionSourceAdapter = {
   id: "claude-code",
-  public: false,
+  public: true,
   displayName: "Claude Code",
   defaultRoot() {
     return resolve(homedir(), ".claude", "projects");

--- a/src/sources/codex.test.ts
+++ b/src/sources/codex.test.ts
@@ -17,7 +17,10 @@ describe("codex source adapter", () => {
     expect(getSessionSourceAdapter()).toBe(codexSourceAdapter);
     expect(getSessionSourceAdapter("codex")).toBe(codexSourceAdapter);
     expect(listSessionSourceAdapters().map((adapter) => adapter.id)).toContain("codex");
-    expect(listSessionSourceAdapters().filter((adapter) => adapter.public).map((adapter) => adapter.id)).toEqual(["codex"]);
+    expect(listSessionSourceAdapters().filter((adapter) => adapter.public).map((adapter) => adapter.id)).toEqual([
+      "codex",
+      "claude-code",
+    ]);
     expect(codexSourceAdapter.public).toBe(true);
   });
 


### PR DESCRIPTION
<!-- mainline:pr-description:start -->
## Mainline Intent

**Intent:** `int_8255133f`
**Status:** `proposed`
**Title:** 发布 Claude Code experimental public support

### What changed

将 claude-code 从 private adapter 提升为 public CLI source，开放固定命令面的 --source claude-code，补齐 focused tests、当前态文档、发行 skill 文案，并把版本 bump 到 0.3.6。

### Why

用户目标是把 Claude Code support 继续推进到可发布状态。当前实现已经有可工作的 adapter，缺口主要在 public CLI gate、用户面文档/skill 对齐，以及版本与发布闭环。

### Decisions

- **Claude Code public contract should be stable or experimental:** Shipped claude-code as experimental public support on the fixed command surface while keeping Codex as the default omitted-source behavior. (The repo already had a functioning transcript reader and source-aware storage/query path, but current evidence still does not justify a stable raw-format promise.)
  - Rejected: Keep claude-code private/non-public and defer all public exposure again.
  - Rejected: Claim stable public support immediately without preserving the experimental contract wording.
- **How to expose public sources in the CLI:** Made public source resolution derive from registered public adapters and updated help/error text to advertise codex|claude-code consistently. (This keeps the fixed command surface intact while making public-source gating match adapter registration instead of a codex-only special case.)
- **What user-facing artifacts to update with the new source boundary:** Updated current-state README, architecture/roadmap docs, distributable skill source, and skill references to describe claude-code as public but experimental. (Without these updates, checkout behavior, release guidance, and installed-skill guidance would drift and overstate the old private boundary.)

**Subsystems:** README.md, docs, package-lock.json, package.json, skill-packages, src
<!-- mainline:pr-description:end -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose experimental public support for Claude Code in the `@act0r/cxs` CLI, enabling full CLI usage with `--source claude-code` while keeping Codex as the default. Updates docs, tests, and help/error text; release bumps to 0.3.6.

- **New Features**
  - Promote `claude-code` to a public adapter with default root at `~/.claude/projects`.
  - Support `--source claude-code` on all fixed commands (status/sync/find/read-range/read-page/list/stats); omitting `--source` still uses Codex.
  - Help text now lists public sources from the registry; unknown sources return `unsupported_source` with clearer messaging.
  - Update selector/JSON schemas and docs/skills to include `claude-code` as experimental (not a stable raw-format promise).
  - Add focused E2E tests for `claude-code` and unknown-source rejection; bump `@act0r/cxs` to 0.3.6 and refresh package description/keywords.

<sup>Written for commit 69c2cda5768deceeeeb924fd46872216b1e49936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/cxs/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

