### PR TITLE
feat(cli): 让 find 默认跨源搜索

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 [https://cxs.chen.rs](https://cxs.chen.rs)
 
-`cxs` is a local-first CLI for searching Codex session logs. It is designed for
-progressive retrieval: find the right session first, then read only the relevant
-range or page.
+`cxs` is a local-first CLI for searching local Codex and Claude Code session
+logs. It is designed for progressive retrieval: find the right session first,
+then read only the relevant range or page.
 
 The public session sources in this checkout are `codex` and experimental
-`claude-code`. The fixed command set accepts `--source <id>`, and omitting
-`--source` still means Codex. Claude Code support is public in this checkout,
-but it is still an experimental transcript-reader contract rather than a stable
+`claude-code`. `find` searches all public indexed sources by default so agents
+do not have to guess where a memory came from. Other fixed commands still treat
+omitted `--source` as Codex unless they receive a source-qualified session ref
+such as `claude-code:<id>`. Claude Code support is public in this checkout, but
+it is still an experimental transcript-reader contract rather than a stable
 raw-format promise.
 
 When reading this from a source checkout, the installed `cxs` on your `PATH`
@@ -88,8 +90,8 @@ Search and read progressively:
 
 ```bash
 cxs find "health check"
-cxs read-range <sessionUuid> --seq <matchSeq>
-cxs read-page <sessionUuid> --offset 0 --limit 20
+cxs read-range <sessionRef> --seq <matchSeq>
+cxs read-page <sessionRef> --offset 0 --limit 20
 ```
 
 You can run the same flow without global installation:
@@ -105,7 +107,7 @@ npx @act0r/cxs@latest find "health check" --root /Users/you/.codex/sessions
 | --- | --- |
 | `cxs status` | Show execution context, source inventory, index state, and coverage. `--selector` checks whether a target range is fresh. Does not write the index. |
 | `cxs sync --root <dir>\|--cwd <path>\|--selector <json>` | Scan selected sessions for the chosen source and update the SQLite index. This is the only write command. |
-| `cxs find <query>` | Search indexed sessions and return ranked session candidates with minimal snippets. Use `--root`, `--cwd`, and `--sort ended` for scoped "latest + keyword" queries. |
+| `cxs find <query>` | Search indexed sessions across all public sources by default and return ranked session candidates with minimal snippets. Use `--source <id>` to narrow, or `--root`, `--cwd`, and `--sort ended` for scoped "latest + keyword" queries. |
 | `cxs read-range <sessionUuid>` | Read a small message window around a matched sequence or in-session query. |
 | `cxs read-page <sessionUuid>` | Read a session page by offset and limit. |
 | `cxs list` | List indexed sessions without full-text search. |
@@ -115,20 +117,30 @@ All commands that read indexed content support `--json`. Read commands fail
 cleanly if the index has not been created yet.
 
 In source-aware builds, all fixed commands accept `--source <id>`. Public
-values are `codex` and experimental `claude-code`; omitting `--source`
-defaults to Codex, so these are equivalent:
+values are `codex` and experimental `claude-code`.
+
+`find` is the recall primitive and defaults to all public indexed sources:
 
 ```bash
 cxs find "health check"
-cxs find "health check" --source codex
+cxs find "health check" --source all
 ```
 
-Claude Code uses the same fixed command surface:
+Use a source only to narrow or diagnose:
+
+```bash
+cxs find "health check" --source codex
+cxs find "health check" --source claude-code
+```
+
+For `status`, `sync`, `list`, `stats`, and bare read commands, omitting
+`--source` still means Codex. Read commands can also consume the `sessionRef`
+returned by `find` directly:
 
 ```bash
 cxs status --source claude-code --json
 cxs sync --source claude-code --root ~/.claude/projects --json
-cxs find "health check" --source claude-code
+cxs read-range claude-code:<sessionId> --seq <matchSeq>
 ```
 
 Unknown sources still return `unsupported_source` before doing command work.
@@ -180,9 +192,10 @@ order.
 
 ## Sync And Storage
 
-By default, `cxs` reads Codex sessions from `~/.codex/sessions`. With
-`--source claude-code`, the default root is `~/.claude/projects`. Index data is
-stored at:
+By default, source-scoped commands read Codex sessions from
+`~/.codex/sessions`. With `--source claude-code`, the default root is
+`~/.claude/projects`. `find` defaults to searching all public indexed sources
+already present in the SQLite index. Index data is stored at:
 
 ```text
 ~/.local/state/cxs/index.sqlite

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@
 
 这套命令面已经定型，不再保留 `window/session` 旧别名语义。
 
-这些命令都接受可省略的 `--source <id>`。当前公开值是 `codex` 和 experimental `claude-code`，省略时等价于 `--source codex`。传入未知 source 会返回 `unsupported_source`，不会开始扫描、查询或读取。
+这些命令都接受可省略的 `--source <id>`。当前公开值是 `codex` 和 experimental `claude-code`。`find` 是召回入口，省略 `--source` 时默认跨所有 public source 搜索；`--source codex` / `--source claude-code` 用于窄化或诊断。`status`、`sync`、`list`、`stats` 和裸 `read-*` 仍以 Codex 作为省略 source 的兼容默认。传入未知 source 会返回 `unsupported_source`，不会开始扫描、查询或读取。
 
 ## 数据流
 
@@ -31,7 +31,7 @@
 - `codex` adapter 负责默认 root、Codex JSONL inventory/snapshot、Codex parser。
 - `claude-code` adapter 负责默认 root、Claude Code transcript inventory/snapshot、Claude parser，并通过 public fixed-command surface 接入 source-aware indexing / read isolation。
 - 核心层负责 selector、coverage、DB、query/read/list/stats。
-- 公开命令面默认仍是 `codex` source；切换 `--source claude-code` 时走同一组命令，但当前语义仍限于 allowlisted transcript text。
+- `find` 默认跨 public source fanout 并合并结果；切换 `--source claude-code` 时走同一组命令但只查 Claude Code。当前 Claude 语义仍限于 allowlisted transcript text。
 
 Codex adapter 会把原有 `sessionUuid` 映射为 source-aware identity：
 
@@ -98,6 +98,8 @@ SQLite 访问层当前已经按 reader / writer 分流：
 3. 极少数零 token CJK query 在 message 侧回退到 LIKE
 4. 把 raw hits 合并后交给 [ranking.ts](/Users/envvar/work/repos/cxs/src/ranking.ts) 做 session 级排序
 
+CLI 默认 `find` 会对 public sources 执行单源 `findSessions()` fanout，再用 reciprocal-rank fusion 合并候选，避免直接比较不同 source 子集里的 raw FTS 分数。JSON 结果带 `sourceId` 和 `sessionRef`；`sessionRef` 可直接传给 `read-range` / `read-page`，所以 agent 不需要再推断来源。
+
 `messages` 仍然只代表可回读的真实 transcript。session-level 命中会以 `matchSource = "session"` 返回；如果没有真实 message anchor，`matchSeq` 为 `null`，CLI 会建议先 `read-page`。
 
 ### 4. 排序
@@ -125,15 +127,16 @@ SQLite 访问层当前已经按 reader / writer 分流：
 - `compact_text` 解析 JSONL `type=compacted` handoff
 - `reasoning_summary_text` 解析 `response_item.reasoning.summary`
 - `sessions_fts(title + summary_text + compact_text + reasoning_summary_text)` session-level recall
-- source adapter boundary and public `--source codex`
+- source adapter boundary and public `--source codex|claude-code`
 - source-aware selector / coverage / DB identity / query-read isolation
+- default cross-source `find` over public sources
 - strict / best-effort 两种 sync 语义
 - explicit sync scope (`--root` / `--cwd` / `--selector`, canonicalized to selector)
 - source inventory
 - complete coverage 记录
 - manual eval 导出
 - eval batch compare
-- private / non-public Claude Code adapter synthetic path（不是 public CLI source）
+- experimental public Claude Code fixed-command support
 
 ## 当前未落地能力
 
@@ -144,8 +147,7 @@ SQLite 访问层当前已经按 reader / writer 分流：
 - duplicate collapse / diversity control
 - 强约束 gold set / rubric / error taxonomy
 - watcher / daemon / realtime sync
-- 公开 Claude Code adapter / `cxs sync --source claude-code`
-- Claude Code raw JSONL public format decision；private adapter 目前不等同于稳定公开格式承诺
+- Claude Code raw JSONL stable public format decision；当前 experimental transcript reader 不等同于稳定格式承诺
 
 ## 为什么当前文档改成这版
 

--- a/docs/INDEX_COVERAGE_DESIGN.md
+++ b/docs/INDEX_COVERAGE_DESIGN.md
@@ -2,9 +2,9 @@
 
 ## 目标
 
-cxs 是面向 agent 的本地 session retrieval backend。当前公开 source 只有
-Codex。非公开 source 可以先作为 private adapter 做 synthetic verification，
-但必须经过明确 promotion / docs / release / install 边界后才能进入公开命令行为。
+cxs 是面向 agent 的本地 session retrieval backend。当前公开 source 有
+`codex` 和 experimental `claude-code`。`find` 默认跨 public sources 召回；
+其他 source-scoped 命令省略 source 时仍以 Codex 作为兼容默认。
 
 目标态：
 
@@ -128,8 +128,9 @@ cwd_date_range(source, root, cwd, fromDate, toDate)
 
 selector 是 agent 和 CLI 之间的同步契约。
 
-省略 source 的输入只能在 CLI 边界 canonicalize 为当前公开默认 source。进入
-coverage、index、query、read 流程后，selector 必须带 canonical source。
+省略 source 的 selector 输入只能在 CLI 边界 canonicalize。单源命令会补成
+当前命令的 source；默认跨源 `find` 会对每个 public source 建立对应 selector。
+进入 coverage、index、query、read 流程后，selector 必须带 canonical source。
 
 ### Coverage
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 `cxs` 现在已经有一条可用的 retrieval 主链。`title + summary_text + compact_text + reasoning_summary_text` 已作为 session-level recall 面接入，并通过 FTS5 column weights 显式分权；下一步仍不该盲目继续堆排序逻辑，当前最缺的是更可信的 acceptance gate。
 
-当前 source foundation 已落地到 checkout：公开 CLI source 现在有 `codex` 和 experimental `claude-code`，省略 `--source` 仍等价于 `codex`，selector / coverage / DB / query-read 已有 source 维度。`claude-code` 现在已经走通 public fixed-command surface，但仍应描述为 experimental transcript-reader support，而不是稳定 raw-format 承诺。
+当前 source foundation 已落地到 checkout：公开 CLI source 现在有 `codex` 和 experimental `claude-code`，selector / coverage / DB / query-read 已有 source 维度。`find` 省略 `--source` 时默认跨 public sources 搜索并返回可直接读取的 `sessionRef`；其他 source-scoped 命令省略 `--source` 仍以 Codex 作为兼容默认。`claude-code` 现在已经走通 public fixed-command surface，但仍应描述为 experimental transcript-reader support，而不是稳定 raw-format 承诺。
 
 ## 优先级
 
@@ -30,7 +30,7 @@
 建议动作：
 
 - 扩充真实 query 集
-- 给 source-aware 默认行为补 acceptance：省略 source 等价于 `codex`、selector canonical JSON 带显式 `source`、coverage 不跨 source、`claude-code` 的 fixed-command public smoke 持续通过、未知 source 仍返回 `unsupported_source`
+- 给 source-aware 默认行为补 acceptance：默认 `find` 跨 `codex` / `claude-code` 返回结果、结果包含 `sourceId` / `sessionRef`、`sessionRef` 可直接 `read-*`、显式 `--source codex` 可恢复窄化、selector canonical JSON 带显式 `source`、coverage 不跨 source、`claude-code` 的 fixed-command public smoke 持续通过、未知 source 仍返回 `unsupported_source`
 - 继续用 dev-only `~/.agents/skills/cxs-dogfood` 手动策展本机 dogfood golden；不要把私有样本放进发行 skill package
 - 增加更强断言：
   - session 是否对

--- a/eval/dogfood-eval-core.test.ts
+++ b/eval/dogfood-eval-core.test.ts
@@ -118,7 +118,9 @@ function findResult(
 ): FindResult {
   return {
     rank: 1,
+    sourceId: "codex",
     sessionUuid: overrides.sessionUuid ?? "session-a",
+    sessionRef: overrides.sessionUuid ?? "session-a",
     title: "title",
     summaryText: "",
     cwd: overrides.cwd ?? "/tmp/project",

--- a/eval/manual-eval-core.test.ts
+++ b/eval/manual-eval-core.test.ts
@@ -64,7 +64,9 @@ function findResult(
 ): FindResult {
   return {
     rank: overrides.rank ?? 1,
+    sourceId: "codex",
     sessionUuid: overrides.sessionUuid ?? "session-a",
+    sessionRef: overrides.sessionUuid ?? "session-a",
     title: overrides.title ?? "title",
     summaryText: overrides.summaryText ?? "",
     cwd: overrides.cwd ?? "/tmp/project",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@act0r/cxs",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@act0r/cxs",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@act0r/cxs",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "type": "module",
   "description": "Progressive search CLI for local Codex and Claude Code session logs",
   "license": "MIT",

--- a/skill-packages/cxs/SKILL.md
+++ b/skill-packages/cxs/SKILL.md
@@ -5,7 +5,7 @@ description: "Use proactively for local Codex history and personal setup archaeo
 
 # cxs
 
-用 `cxs` 在自己的 SQLite index 里检索旧 agent 对话。当前公开 CLI source 有 `codex` 和 experimental `claude-code`；省略 `--source` 仍等价于 `--source codex`。`claude-code` 现在是 public fixed-command support，但仍是 experimental transcript-reader contract；不要把它说成稳定 raw JSONL 承诺，遇到非 text record 语义缺口也不要跳回 raw source root 取证。各 source 的 raw sessions 都只是 ingest source；正常历史检索只读 cxs index。心法:**先选 retrieval primitive,再定位候选 session,最后用 cxs read 命令拿内容证据**。
+用 `cxs` 在自己的 SQLite index 里检索旧 agent 对话。当前公开 CLI source 有 `codex` 和 experimental `claude-code`；`find` 省略 `--source` 时默认跨 public sources 搜索，agent 正常使用时不要先问用户选来源。`--source codex` / `--source claude-code` 只用于用户指定、缩小范围或诊断。`claude-code` 现在是 public fixed-command support，但仍是 experimental transcript-reader contract；不要把它说成稳定 raw JSONL 承诺，遇到非 text record 语义缺口也不要跳回 raw source root 取证。各 source 的 raw sessions 都只是 ingest source；正常历史检索只读 cxs index。心法:**先选 retrieval primitive,再定位候选 session,最后用 cxs read 命令拿内容证据**。
 
 ## 安装(两步)
 
@@ -41,12 +41,12 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 | 用户需要 | 起手 primitive | 证据规则 |
 | --- | --- | --- |
 | metadata projection: 最早/最新、数量、分布、cwd/session 清单、大 session、时间排序 | 只读 SQLite/bash/jq 查询 cxs index 的 `sessions` 表;必要时用 `list` 辅助 | 只能投影稳定 metadata;任何内容判断都要再 `read-page` / `read-range` |
-| semantic recall: 主题、关键词、"之前讨论过 X 吗"、本机配置考古 | `cxs find <query> --json`,按需要带 `--cwd` / `--root` / `--selector` / `--sort ended` | 用 `find` 召回候选,再用 `read-range` 或 `read-page` 验证 |
-| context reading: 已知 `sessionUuid`、命中 seq、或需要扩大上下文 | `cxs read-range <uuid> --seq/--query [--before N --after M]` 或 `cxs read-page <uuid>` | 内容证据只来自 `read-*` 输出 |
+| semantic recall: 主题、关键词、"之前讨论过 X 吗"、本机配置考古 | `cxs find <query> --json`,默认跨 public sources；按需要带 `--cwd` / `--root` / `--selector` / `--sort ended` | 用 `find` 召回候选,再用结果里的 `sessionRef` 做 `read-range` 或 `read-page` 验证 |
+| context reading: 已知 `sessionUuid` / `sessionRef`、命中 seq、或需要扩大上下文 | `cxs read-range <sessionRef> --seq/--query [--before N --after M]` 或 `cxs read-page <sessionRef>` | 内容证据只来自 `read-*` 输出 |
 | coverage/freshness/index availability: 索引缺失、coverage stale、要决定是否同步 | `cxs status --json` / `status --cwd` / `status --selector` | `status` 不回答内容问题,只决定 coverage 和 sync 需求 |
 | mutation: 建索引或更新 coverage | `cxs sync --cwd/--root/--selector` | 普通检索不要 `--prune`;只有用户明确要求清理已消失 source 的旧索引记录才用 |
 
-在支持 source-aware CLI 的版本里,所有固定命令都可带 `--source <id>`；当前 public CLI 支持 `codex` 和 experimental `claude-code`，省略等价于 `--source codex`。遇到 `unsupported_source`，说明 source id 未知，不要改用 raw source root。Claude Code 支持已公开，但仍是 experimental transcript-reader support；如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
+在支持 source-aware CLI 的版本里,所有固定命令都可带 `--source <id>`；当前 public CLI 支持 `codex` 和 experimental `claude-code`。`find` 省略 `--source` 等价于跨 public sources 搜索，显式 `--source all` 也可以；其他命令省略 source 仍按 Codex 兼容默认处理。遇到 `unsupported_source`，说明 source id 未知，不要改用 raw source root。Claude Code 支持已公开，但仍是 experimental transcript-reader support；如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
 
 `find` / `list` 返回零结果不是结束条件。遇到零结果、用户说“应该有”、问题涉及最近/当前 repo、或 JSON 里有 `nextAction` 时,必须先按同一范围做 coverage check:
 
@@ -75,8 +75,9 @@ npx skills add catoncat/cxs --full-depth --skill cxs -g -a codex -y
 - `sync` 默认保留已索引历史；raw JSONL 从 source snapshot 中消失后，不要引导用户改查另一个 root。只有用户明确要让 cxs 丢弃 source 中已经消失的旧记录时才用 `sync --prune`
 - 用 `status --cwd <path> --json` 或 `status --selector '<json>' --json` 检查目标范围；`requestedCoverage.recommendedAction === "query"` 时直接查，`"sync"` 时才同步
 - `stats.sessionCount` 很多不等于目标范围有 source-aware complete coverage；fresh `{"source":"codex","kind":"all",...}` coverage 可以覆盖同 source/root 下的 cwd/date 子 selector
-- "最新/最近 + 关键词"不要直接把默认 `find` 结果当最新；用 `find <query> --cwd <path> --sort ended` 或 `find <query> --root <dir> --sort ended`，必要时 `--exclude-session <current_uuid>` 排除当前会话/self-hit
+- "最新/最近 + 关键词"不要直接把默认 `find` 结果当最新；用 `find <query> --cwd <path> --sort ended` 或 `find <query> --root <dir> --sort ended`，必要时 `--exclude-session <current_uuid>` 排除当前会话/self-hit。若用户明确限定 Codex 或 Claude Code，再加 `--source <id>`。
 - 混合自然语言 + 英文技术词的问题可以先直接 `find` 原句；新版 CLI 在严格召回为 0 时会保守提取 ASCII 技术词做一次 relaxed recall。仍要用 `read-range` / `read-page` 验证内容，不要只凭命中标题下结论。
+- `find --json` 结果包含 `sourceId` 和 `sessionRef`;后续 read 优先直接用 `sessionRef`。不要自己从 uuid 猜 source。
 - `matchSource = "session"` 时 `matchSeq = null`;这种命中先 `read-page` 抽样,**不要伪造 `read-range --seq`**
 - 用户给 cwd 但不确定 sync 状态 → `status --json`;确认绝对 cwd 后跑 `status --cwd <path>`;缺失/stale 才 `sync --cwd <path>`
 - `find --json` / `list --json` 零结果时看 `nextAction`:它是防止 agent 放弃的机器可读提示。按提示选择/检查 selector、必要时同步、再重试。

--- a/skill-packages/cxs/references/cli-surface.md
+++ b/skill-packages/cxs/references/cli-surface.md
@@ -16,7 +16,7 @@ export CXS_BIN=/absolute/path/to/bin/cxs
 
 metadata-only 问题可以直接对 cxs SQLite index 做只读 projection,例如时间排序、数量、cwd 分布；内容判断仍必须回到 `read-page` / `read-range`。
 
-支持 source-aware CLI 的版本里,所有固定命令都接受 `--source <id>`。当前公开 source 是 `codex` 和 experimental `claude-code`，省略等价于 `--source codex`。未知 source 会返回 `unsupported_source`。Claude Code 已是 public CLI 可用 adapter，但仍是 experimental transcript-reader support；不要把它理解成稳定 raw transcript 格式承诺。如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
+支持 source-aware CLI 的版本里,所有固定命令都接受 `--source <id>`。当前公开 source 是 `codex` 和 experimental `claude-code`。`find` 省略 `--source` 时默认跨 public sources 搜索，`--source all` 是显式同义写法；`--source codex` / `--source claude-code` 用于缩小范围或诊断。`status`、`sync`、`list`、`stats` 和裸 `read-*` 省略 source 时仍按 Codex 兼容默认处理；read 命令也可以直接消费 `find` 返回的 `sessionRef`。未知 source 会返回 `unsupported_source`。Claude Code 已是 public CLI 可用 adapter，但仍是 experimental transcript-reader support；不要把它理解成稳定 raw transcript 格式承诺。如果安装版直接报 unknown option `--source`,它是旧 CLI；省略 source flags 或更新 CLI。
 
 缺少 cxs 索引时,`find` / `read-range` / `read-page` / `list` / `stats --json` 返回:
 
@@ -92,6 +92,8 @@ Example:
 
 Purpose: 搜索相关 session，返回最小必要命中。用于 semantic recall,不是数量/排序/分布这类 metadata projection 的默认工具。
 
+`find` 默认搜索所有 public indexed sources。结果里的 `sourceId` 告诉你来源，`sessionRef` 是后续 `read-range` / `read-page` 的首选输入。只有用户指定来源、要缩小范围、或在诊断某个 source 的覆盖问题时才加 `--source codex` / `--source claude-code`。
+
 text header 带效率回述:`cxs find "q" · 检索 ~N 条 · 结果 R · Xms`(`检索 ~N` = 范围内语料规模诚实分母,`--json` 里是 `scannedMessageCount` / `elapsedMs`)。`read-range` / `read-page` 的 header 带「读取 K 条 / 本 session 共 T 条 · Xms」和 `total=… · hasMore=… · Xms`。这些数字用于「结果回述」那段克制地告诉用户省了多少,**不要据此编造「省 X%」**。
 
 效率回述默认开,环境变量 `CXS_STATS=0`(或 `off`/`false`/`no`)可关闭文本 header 里的注解(`检索 ~N 条 / 读取 K 条 / Xms`);`--json` 的 `scannedMessageCount` / `elapsedMs` 与 `read-page` 的 `total/hasMore` 等功能字段始终保留。关闭时文本里没有可锚的数字,直接省掉效率尾注、别硬编。
@@ -111,7 +113,7 @@ Options:
 
 | option | 说明 |
 | --- | --- |
-| `--source <id>` | 公开值是 `codex` 和 experimental `claude-code`;省略等价于 `codex` |
+| `--source <id>` | 公开值是 `codex`、experimental `claude-code` 或 `all`;省略等价于 `all` |
 | `--root <dir>` | 限定到整个 sessions 根目录；也作为 selector 默认 root |
 | `--cwd <path>` | 限定到指定 cwd selector |
 | `--selector <json>` | 结构化查询范围；可省略 `root` |
@@ -125,9 +127,9 @@ Purpose: 围绕命中点读取局部上下文。内容证据优先用它。
 
 Notes:
 
-- 必须显式传 `<sessionUuid>`
+- 必须显式传 `<sessionUuid>` 或 `find` 返回的 `<sessionRef>`
 - 必须二选一提供 `--seq` 或 `--query`
-- 可选 `--source codex|claude-code`;省略等价于 Codex。`<source>:<uuid>` qualifier 只在 source 匹配时有效。
+- 可选 `--source codex|claude-code`;省略等价于 Codex。`<source>:<uuid>` qualifier 会直接决定读取 source；若同时传 `--source`,两者必须匹配。
 
 Example:
 
@@ -141,6 +143,7 @@ Example:
 Purpose: 顺序分页读取某个 session 的消息。metadata projection 只能给候选;要确认"当时说了什么/是否有意义",用 `read-page` 或 `read-range`。
 
 可选 `--source codex|claude-code`;省略等价于 Codex。
+如果传入 `claude-code:<uuid>` 这类 `sessionRef`,无需再传 `--source claude-code`。
 
 Example:
 

--- a/skill-packages/cxs/references/failure-cookbook.md
+++ b/skill-packages/cxs/references/failure-cookbook.md
@@ -4,7 +4,7 @@
 
 | 症状 | 先跑 | 处理 |
 | --- | --- | --- |
-| `find` 零结果但用户坚持存在 | `status --cwd <path> --json` 或 `status --selector '<json>' --json` | 看目标范围的 `requestedCoverage`；必要时 `sync --cwd` / `sync --root` / `sync --selector`；再带同范围查询 |
+| `find` 零结果但用户坚持存在 | 对相关 public source 跑 `status --source <id> --cwd <path> --json` 或 `status --source <id> --selector '<json>' --json` | 看每个目标范围的 `requestedCoverage`；必要时按 source 同步；再带同范围查询 |
 | `sync` 非零退出带 per-file errors | `sync --root <dir> --json 2>&1` 或 `sync --selector '<json>' --json 2>&1` | 看 `errorDetails[]`；默认严格模式；只在允许部分成功时加 `--best-effort` |
 | `sync` 返回 `selector_required` | 原命令补 `--root`、`--cwd` 或 `--selector` | sync 必须显式给范围；不需要把 root 写进 JSON |
 | `find/list/stats/read-*` 输出 `index_unavailable` | `status --json` | 索引还没建立；选择范围后 `sync --root` / `sync --cwd` / `sync --selector` |
@@ -18,21 +18,22 @@
 | 用户问“最近本项目讨论了什么” | `list --cwd <abs_cwd> --sort ended --json` | 这是 metadata/listing 问题；索引不可用或 coverage 不明时再 `status --cwd` |
 | 用户说“在 X 项目里” | `status --json` | 从 `sourceInventory.cwdGroups` 选择 cwd selector |
 | 从其他 cwd 调用找不到 db | `stats --json` | 看 `dbPath`；必要时显式传 `--db` |
-| `unsupported_source` | 检查 source id 拼写，必要时改回省略 `--source`、`--source codex` 或 `--source claude-code` | 当前公开 source 是 `codex` 和 experimental `claude-code`；不要因为 source id 写错就跳回 raw source root |
+| `unsupported_source` | 检查 source id 拼写；`find` 可省略 `--source` 或用 `--source all`，窄化时用 `--source codex` / `--source claude-code` | 当前公开 source 是 `codex` 和 experimental `claude-code`；不要因为 source id 写错就跳回 raw source root |
 
 ## Find zero results but user insists it exists
 
 先看 `find --json` / `list --json` 有没有 `nextAction`。有就按它执行；没有也不要直接放弃,先确认目标范围 coverage。
 
 ```bash
-"${CXS_BIN:-cxs}" status --json
+"${CXS_BIN:-cxs}" status --source codex --json
+"${CXS_BIN:-cxs}" status --source claude-code --json
 ```
 
 如果目标范围没有 fresh coverage，先同步明确范围。cwd/root 用快捷方式，日期窗再用 selector：
 
 ```bash
-"${CXS_BIN:-cxs}" status --cwd /Users/me/work/foo --json
-"${CXS_BIN:-cxs}" sync --cwd /Users/me/work/foo
+"${CXS_BIN:-cxs}" status --source codex --cwd /Users/me/work/foo --json
+"${CXS_BIN:-cxs}" sync --source codex --cwd /Users/me/work/foo
 ```
 
 如果 `status --selector` 返回 `recommendedAction: "query"`，跳过 `sync`。

--- a/skill-packages/cxs/references/json-schema.md
+++ b/skill-packages/cxs/references/json-schema.md
@@ -7,11 +7,13 @@ Top-level shape:
 ```ts
 {
   query: string;
+  sourceIds: Array<"codex" | "claude-code">;
   sort: "relevance" | "ended" | "started";
   excludedSessions: string[];
   results: FindResult[];
   scannedMessageCount: number; // 检索覆盖范围(selector 限定后)内的消息总数,做诚实分母
   coverage: CoverageStatus;
+  coverageBySource?: Array<{ sourceId: "codex" | "claude-code"; coverage: CoverageStatus }>;
   nextAction?: QueryNextAction;
   elapsedMs: number; // 端到端耗时(进程启动到输出),仅 CLI 输出注入,非 query 层字段
 }
@@ -24,7 +26,9 @@ Top-level shape:
 ```ts
 {
   rank: number;
+  sourceId: "codex" | "claude-code";
   sessionUuid: string;
+  sessionRef: string;
   title: string;
   summaryText: string;
   cwd: string;
@@ -39,6 +43,11 @@ Top-level shape:
   snippet: string;
 }
 ```
+
+`find` defaults to cross-source recall across public indexed sources. Use
+`sourceIds` to see which sources participated. Use each result's `sessionRef`
+as the read command input; for Codex it is usually the bare UUID, and for
+Claude Code it is source-qualified such as `claude-code:<id>`.
 
 `matchSource = "session"` means the hit came from session-level fields such as title, derived summary, compact handoff, or reasoning summary rather than a concrete message. In that case `matchSeq` is `null`; use `read-page` first instead of fabricating a `read-range --seq` anchor.
 

--- a/skill-packages/cxs/references/progressive-workflow.md
+++ b/skill-packages/cxs/references/progressive-workflow.md
@@ -19,7 +19,7 @@ Hard rules:
 - Do not use `sync --prune` for normal retrieval.
 - `find` default sort is relevance; use `--sort ended` only when the user's question is time-oriented.
 - `matchSource = "session"` means `matchSeq = null`; use `read-page` instead of inventing a seq.
-- Current public sources are `codex` and experimental `claude-code`; omit `--source` or pass `--source codex` for the default. Claude Code is part of the normal CLI surface now, but it is still not a stable raw-format promise.
+- Current public sources are `codex` and experimental `claude-code`; `find` omits `--source` to search all public indexed sources by default. Pass `--source codex` or `--source claude-code` only to narrow or diagnose. Other source-scoped commands still omit `--source` as Codex-compatible default. Claude Code is part of the normal CLI surface now, but it is still not a stable raw-format promise.
 
 ## Scenario 1: Metadata Projection
 
@@ -52,7 +52,7 @@ sqlite3 -readonly "$DB_PATH" \
 这类需要主题召回,用 `find`:
 
 ```bash
-"${CXS_BIN:-cxs}" find "cf tunnel" --root /Users/me/.codex/sessions --json -n 5
+"${CXS_BIN:-cxs}" find "cf tunnel" --json -n 5
 ```
 
 如果命令返回 `index_unavailable`,或者你需要确认目标范围 coverage,再用 `status` / `sync`:
@@ -65,13 +65,13 @@ sqlite3 -readonly "$DB_PATH" \
 候选出来后读内容:
 
 ```bash
-"${CXS_BIN:-cxs}" read-range <sessionUuid> --seq <matchSeq> --before 4 --after 8 --json
+"${CXS_BIN:-cxs}" read-range <sessionRef> --seq <matchSeq> --before 4 --after 8 --json
 ```
 
 如果 `matchSeq` 是 `null`,改用:
 
 ```bash
-"${CXS_BIN:-cxs}" read-page <sessionUuid> --offset 0 --limit 40 --json
+"${CXS_BIN:-cxs}" read-page <sessionRef> --offset 0 --limit 40 --json
 ```
 
 ## Scenario 3: Coverage Diagnosis

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -214,7 +214,7 @@ describe("cxs cli", () => {
     expect(payload.coverage).toEqual([]);
   });
 
-  test("fixed commands accept explicit --source codex while omitted source remains Codex", async () => {
+  test("fixed commands accept explicit --source codex and omitted find still sees Codex rows", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-cli-source-codex-"));
     tempDirs.push(base);
     const root = join(base, "sessions");
@@ -460,6 +460,94 @@ describe("cxs cli", () => {
     expect(pagePayload.totalCount).toBe(2);
   });
 
+  test("find defaults to public cross-source search and returned session refs are directly readable", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-cross-source-find-"));
+    tempDirs.push(base);
+
+    const codexRoot = join(base, "codex-sessions");
+    const codexDay = join(codexRoot, "2026", "04", "20");
+    mkdirSync(codexDay, { recursive: true });
+    writeFileSync(
+      join(codexDay, "rollout-2026-04-20T10-00-00-15151515-1515-4515-8515-151515151515.jsonl"),
+      [
+        line("session_meta", { id: "15151515-1515-4515-8515-151515151515", cwd: "/tmp/cross-codex" }),
+        line("event_msg", { type: "user_message", message: "cross shared codex unique" }),
+      ].join("\n"),
+    );
+
+    const claudeRoot = join(base, "claude-projects");
+    const claudeProject = join(claudeRoot, "synthetic-project");
+    mkdirSync(claudeProject, { recursive: true });
+    writeFileSync(
+      join(claudeProject, "conversation.jsonl"),
+      [
+        claudeLine({
+          type: "user",
+          sessionId: "cli-cross-claude",
+          cwd: "/tmp/cross-claude",
+          timestamp: "2026-06-06T00:00:00.000Z",
+          message: { content: "cross shared claude unique" },
+        }),
+        claudeLine({
+          type: "assistant",
+          sessionId: "cli-cross-claude",
+          cwd: "/tmp/cross-claude",
+          timestamp: "2026-06-06T00:00:01.000Z",
+          message: { content: "cross shared claude reply" },
+        }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const codexSync = await runCli(["sync", "--source", "codex", "--root", codexRoot, "--db", dbPath, "--json"]);
+    const claudeSync = await runCli(["sync", "--source", "claude-code", "--root", claudeRoot, "--db", dbPath, "--json"]);
+    expect(codexSync.exitCode).toBe(0);
+    expect(claudeSync.exitCode).toBe(0);
+
+    const found = await runCli(["find", "cross shared", "--db", dbPath, "--json"]);
+    expect(found.exitCode).toBe(0);
+    const findPayload = JSON.parse(found.stdout) as {
+      sourceIds: string[];
+      results: Array<{ sourceId: string; sessionUuid: string; sessionRef: string; matchSeq: number | null }>;
+    };
+    expect(findPayload.sourceIds).toEqual(["codex", "claude-code"]);
+    expect(findPayload.results.map((result) => result.sourceId).sort()).toEqual(["claude-code", "codex"]);
+    const claudeHit = findPayload.results.find((result) => result.sourceId === "claude-code");
+    expect(claudeHit?.sessionRef).toBe("claude-code:cli-cross-claude");
+    expect(claudeHit?.matchSeq).toBe(0);
+
+    const explicitCodex = await runCli(["find", "cross shared", "--source", "codex", "--db", dbPath, "--json"]);
+    expect(explicitCodex.exitCode).toBe(0);
+    const explicitCodexPayload = JSON.parse(explicitCodex.stdout) as {
+      sourceIds: string[];
+      results: Array<{ sourceId: string }>;
+    };
+    expect(explicitCodexPayload.sourceIds).toEqual(["codex"]);
+    expect(explicitCodexPayload.results.map((result) => result.sourceId)).toEqual(["codex"]);
+
+    const range = await runCli([
+      "read-range",
+      claudeHit?.sessionRef ?? "",
+      "--seq",
+      String(claudeHit?.matchSeq ?? 0),
+      "--before",
+      "0",
+      "--after",
+      "0",
+      "--db",
+      dbPath,
+      "--json",
+    ]);
+    expect(range.exitCode).toBe(0);
+    const rangePayload = JSON.parse(range.stdout) as {
+      session: { sourceId: string; sessionUuid: string };
+      messages: Array<{ contentText: string }>;
+    };
+    expect(rangePayload.session.sourceId).toBe("claude-code");
+    expect(rangePayload.session.sessionUuid).toBe("claude-code:cli-cross-claude");
+    expect(rangePayload.messages[0]?.contentText).toBe("cross shared claude unique");
+  });
+
   test("sync with cwd selector writes coverage and find stays scoped", async () => {
     const base = mkdtempSync(join(tmpdir(), "cxs-cli-selector-"));
     tempDirs.push(base);
@@ -489,7 +577,7 @@ describe("cxs cli", () => {
     expect(syncPayload.coverage.written).toBe(true);
     expect(syncPayload.coverage.selector).toMatchObject({ kind: "cwd", cwd: "/tmp/alpha" });
 
-    const found = await runCli(["find", "shared needle", "--selector", selector, "--db", dbPath, "--json"]);
+    const found = await runCli(["find", "shared needle", "--source", "codex", "--selector", selector, "--db", dbPath, "--json"]);
     expect(found.exitCode).toBe(0);
     const findPayload = JSON.parse(found.stdout) as {
       results: Array<{ sessionUuid: string; cwd: string }>;
@@ -645,7 +733,19 @@ describe("cxs cli", () => {
     const synced = await runCli(["sync", "--root", root, "--selector", selectorWithoutRoot, "--db", dbPath, "--json"]);
     expect(synced.exitCode).toBe(0);
 
-    const found = await runCli(["find", "default root needle", "--root", root, "--selector", selectorWithoutRoot, "--db", dbPath, "--json"]);
+    const found = await runCli([
+      "find",
+      "default root needle",
+      "--source",
+      "codex",
+      "--root",
+      root,
+      "--selector",
+      selectorWithoutRoot,
+      "--db",
+      dbPath,
+      "--json",
+    ]);
     expect(found.exitCode).toBe(0);
     const payload = JSON.parse(found.stdout) as {
       results: Array<{ sessionUuid: string }>;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ import {
 import { canonicalizeSelector, parseSelectorJson, SelectorParseError, selectorSource } from "./selector";
 import { collectStatus } from "./status";
 import { SyncLockTimeoutError } from "./sync-lock";
-import type { FindSort, Selector, SessionListSort, SessionSourceId } from "./types";
+import type { FindResult, FindSort, FindSummary, QueryNextAction, Selector, SessionListSort, SessionSourceId } from "./types";
 
 const program = new Command();
 
@@ -135,7 +135,7 @@ program
 program
   .command("find <query>")
   .description("搜索相关 session，返回最小必要命中")
-  .option("--source <id>", `session source (public: ${publicSourceLabel()})`)
+  .option("--source <id>", `session source filter (public: all|${publicSourceLabel()}; default: all)`)
   .option("-n, --limit <n>", "返回条数", "10")
   .option("--root <dir>", "限定到指定 sessions 根目录；也作为 selector 默认 root")
   .option("--selector <json>", "结构化查询范围 JSON")
@@ -146,15 +146,18 @@ program
   .option("--json", "输出 JSON")
   .action((query, options) => {
     runReadCommand(Boolean(options.json), () => {
-      const sourceId = publicSource(options.source);
       const limit = parsePositiveInt(options.limit, 10);
-      const selector = optionalSelector({ ...options, source: sourceId, rootOnlySelector: true });
       const sort = normalizeFindSort(options.sort);
-      const result = findSessions(options.db, query, limit, selector, {
-        sourceId,
-        sort,
-        excludeSessions: options.excludeSession ?? [],
+      const sourceIds = publicFindSources(options.source, options.selector);
+      const summaries = sourceIds.map((sourceId) => {
+        const selector = optionalSelector({ ...options, source: sourceId, rootOnlySelector: true });
+        return findSessions(options.db, query, limit, selector, {
+          sourceId,
+          sort,
+          excludeSessions: options.excludeSession ?? [],
+        });
       });
+      const result = mergeFindSummaries(query, sort, options.excludeSession ?? [], summaries, limit);
       // performance.now() 自 timeOrigin(进程启动)起算 ≈ 本次端到端耗时,
       // 含 better-sqlite3 模块加载;cxs 是一次性进程,所以这就是诚实的端到端。
       const elapsedMs = Math.round(performance.now());
@@ -178,7 +181,7 @@ program
   .option("--json", "输出 JSON")
   .action((sessionUuid, options) => {
     runReadCommand(Boolean(options.json), () => {
-      const sourceId = publicSource(options.source);
+      const sourceId = publicReadSource(options.source, sessionUuid);
       const result = getMessageRange(options.db, sessionRefForSource(sessionUuid, sourceId), {
         seq: optionalInt(options.seq),
         query: options.query,
@@ -212,7 +215,7 @@ program
   .option("--json", "输出 JSON")
   .action((sessionUuid, options) => {
     runReadCommand(Boolean(options.json), () => {
-      const sourceId = publicSource(options.source);
+      const sourceId = publicReadSource(options.source, sessionUuid);
       const result = getMessagePage(
         options.db,
         sessionRefForSource(sessionUuid, sourceId),
@@ -359,6 +362,21 @@ function publicSource(value: string | undefined): SessionSourceId {
   throw new SourceOptionError(sourceId || "(empty)");
 }
 
+function publicFindSources(value: string | undefined, selectorJson?: string): SessionSourceId[] {
+  const source = value?.trim();
+  if (source && source !== "all") return [publicSource(source)];
+
+  const selectorSource = sourceFromSelectorJson(selectorJson);
+  if (selectorSource) return [selectorSource];
+
+  return getPublicSourceAdapters().map((adapter) => adapter.id);
+}
+
+function publicReadSource(value: string | undefined, sessionRef: string): SessionSourceId {
+  if (typeof value === "string") return publicSource(value);
+  return sourceFromSessionRef(sessionRef) ?? publicSource(undefined);
+}
+
 function publicSourceLabel(): string {
   return getPublicSourceAdapters()
     .map((adapter) => adapter.id)
@@ -376,6 +394,129 @@ function resolvePublicSourceAdapter(sourceId: string) {
 
 function getPublicSourceAdapters() {
   return listSessionSourceAdapters().filter((adapter) => adapter.public);
+}
+
+function sourceFromSelectorJson(selectorJson: string | undefined): SessionSourceId | null {
+  if (!selectorJson) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(selectorJson) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || typeof parsed.source !== "string") return null;
+  return publicSource(parsed.source);
+}
+
+function sourceFromSessionRef(sessionRef: string): SessionSourceId | null {
+  const separator = sessionRef.indexOf(":");
+  if (separator <= 0) return null;
+  return publicSource(sessionRef.slice(0, separator));
+}
+
+function mergeFindSummaries(
+  query: string,
+  sort: FindSort,
+  excludedSessions: string[],
+  summaries: FindSummary[],
+  limit: number,
+): FindSummary {
+  if (summaries.length === 1) return summaries[0]!;
+
+  const results = mergeFindResults(summaries.flatMap((summary) => summary.results), sort, limit);
+  const coverageBySource = summaries.flatMap((summary) => summary.coverageBySource ?? summary.sourceIds.map((sourceId) => ({
+    sourceId,
+    coverage: summary.coverage,
+  })));
+  const coverage = {
+    requested: null,
+    complete: coverageBySource.every((entry) => entry.coverage.complete),
+    freshness: "not_checked" as const,
+    coveringSelectors: coverageBySource.flatMap((entry) => entry.coverage.coveringSelectors),
+  };
+  return {
+    query,
+    sourceIds: summaries.flatMap((summary) => summary.sourceIds),
+    sort,
+    excludedSessions: uniqueNonEmpty(excludedSessions),
+    results,
+    scannedMessageCount: summaries.reduce((total, summary) => total + summary.scannedMessageCount, 0),
+    coverage,
+    coverageBySource,
+    nextAction: results.length === 0 ? buildCrossSourceZeroResultsNextAction() : undefined,
+  };
+}
+
+function mergeFindResults(results: FindResult[], sort: FindSort, limit: number): FindResult[] {
+  const deduped = new Map<string, FindResult>();
+  for (const result of results) {
+    const key = `${result.sourceId}\0${result.sessionRef}`;
+    const existing = deduped.get(key);
+    if (!existing || result.rank < existing.rank || (result.rank === existing.rank && result.score > existing.score)) {
+      deduped.set(key, result);
+    }
+  }
+
+  const rows = [...deduped.values()];
+  if (sort === "relevance") {
+    return rows
+      .map((result) => ({ ...result, score: reciprocalRankScore(result.rank) }))
+      .sort(compareMergedRelevance)
+      .slice(0, limit)
+      .map((result, index) => ({ ...result, rank: index + 1 }));
+  }
+
+  return rows
+    .sort((left, right) => compareMergedTime(left, right, sort))
+    .slice(0, limit)
+    .map((result, index) => ({ ...result, rank: index + 1 }));
+}
+
+function reciprocalRankScore(rank: number): number {
+  return 1 / (60 + rank);
+}
+
+function compareMergedRelevance(left: FindResult, right: FindResult): number {
+  if (right.score !== left.score) return right.score - left.score;
+  if (right.endedAt > left.endedAt) return 1;
+  if (right.endedAt < left.endedAt) return -1;
+  return compareStableFindResult(left, right);
+}
+
+function compareMergedTime(left: FindResult, right: FindResult, sort: FindSort): number {
+  const leftTime = sort === "started" ? left.startedAt : left.endedAt;
+  const rightTime = sort === "started" ? right.startedAt : right.endedAt;
+  if (rightTime > leftTime) return 1;
+  if (rightTime < leftTime) return -1;
+  if (right.score !== left.score) return right.score - left.score;
+  return compareStableFindResult(left, right);
+}
+
+function compareStableFindResult(left: FindResult, right: FindResult): number {
+  const sourceOrder = left.sourceId.localeCompare(right.sourceId);
+  if (sourceOrder !== 0) return sourceOrder;
+  return left.sessionRef.localeCompare(right.sessionRef);
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  const seen = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return [...seen];
+}
+
+function buildCrossSourceZeroResultsNextAction(): QueryNextAction {
+  return {
+    kind: "choose_selector_then_check_coverage",
+    reason: "zero_results_without_selector",
+    steps: [
+      "Run cxs status --source <id> for each relevant public source and selector.",
+      "If any source reports requestedCoverage.recommendedAction as sync, run cxs sync --source <id> for that source and selector.",
+      "Retry this find before concluding nothing exists.",
+    ],
+  };
 }
 
 function emitSourceError(error: SourceOptionError, jsonMode: boolean): void {

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -12,7 +12,9 @@ function captured(spy: ReturnType<typeof vi.spyOn>): string {
 function makeFindResult(overrides: Partial<FindResult> = {}): FindResult {
   return {
     rank: 1,
+    sourceId: "codex",
     sessionUuid: "11111111-1111-4111-8111-111111111111",
+    sessionRef: "11111111-1111-4111-8111-111111111111",
     title: "排查 deploy",
     summaryText: "",
     cwd: "/tmp/project-a",

--- a/src/format.ts
+++ b/src/format.ts
@@ -59,15 +59,15 @@ export function printFindResults(
     console.log(chalk.bold(`[${result.rank}] ${result.title || "(no title)"}`));
     console.log(chalk.gray(`${result.startedAt} · ${result.cwd || "-"}`));
     const matchPoint = result.matchSeq === null ? "session-level" : `seq=${result.matchSeq}`;
-    console.log(chalk.gray(`uuid=${result.sessionUuid} · ${matchPoint} · matches=${result.matchCount}`));
+    console.log(chalk.gray(`source=${result.sourceId} · uuid=${result.sessionUuid} · ${matchPoint} · matches=${result.matchCount}`));
     if (result.summaryText) {
       console.log(chalk.gray(trimSummary(result.summaryText)));
     }
     console.log(stripMarks(result.snippet));
     if (result.matchSeq === null) {
-      console.log(chalk.gray(`next: cxs read-page ${result.sessionUuid} --offset 0 --limit 40`));
+      console.log(chalk.gray(`next: cxs read-page ${result.sessionRef} --offset 0 --limit 40`));
     } else {
-      console.log(chalk.gray(`next: cxs read-range ${result.sessionUuid} --seq ${result.matchSeq}`));
+      console.log(chalk.gray(`next: cxs read-range ${result.sessionRef} --seq ${result.matchSeq}`));
     }
   }
 }

--- a/src/query/find.ts
+++ b/src/query/find.ts
@@ -44,11 +44,13 @@ export function findSessions(
     const coverage = buildCoverageStatus(db, selector);
     return {
       query,
+      sourceIds: [sourceId],
       sort,
       excludedSessions,
       results,
       scannedMessageCount: countScannedMessages(db, selector, sourceId),
       coverage,
+      coverageBySource: [{ sourceId, coverage }],
       nextAction: results.length === 0 ? buildZeroResultsNextAction(selector, "this find") : undefined,
     };
   });

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -1,4 +1,4 @@
-import type { FindMatchRole, FindResult, MatchSource, SessionSourceId } from "./types";
+import { DEFAULT_SESSION_SOURCE_ID, type FindMatchRole, type FindResult, type MatchSource, type SessionSourceId } from "./types";
 import { queryTerms, tokenize } from "./tokenize";
 
 export interface RawHitRow {
@@ -162,22 +162,32 @@ function rankAggregates(grouped: Map<string, SessionAggregate>, profile: QueryPr
       return 0;
     });
 
-  return ranked.slice(0, limit).map(({ aggregate, sessionScore }, index) => ({
-    rank: index + 1,
-    sessionUuid: aggregate.row.sessionUuid,
-    title: aggregate.row.title,
-    summaryText: aggregate.row.summaryText,
-    cwd: aggregate.row.cwd,
-    startedAt: aggregate.row.startedAt,
-    endedAt: aggregate.row.endedAt,
-    matchCount: aggregate.hitCount,
-    matchSource: aggregate.bestDisplayRow.matchSource,
-    matchSeq: aggregate.bestDisplayRow.matchSeq,
-    matchRole: aggregate.bestDisplayRow.matchRole,
-    matchTimestamp: aggregate.bestDisplayRow.matchTimestamp,
-    score: sessionScore,
-    snippet: aggregate.bestDisplayRow.snippet,
-  }));
+  return ranked.slice(0, limit).map(({ aggregate, sessionScore }, index) => {
+    const sourceId = aggregate.row.sourceId ?? DEFAULT_SESSION_SOURCE_ID;
+    return {
+      rank: index + 1,
+      sourceId,
+      sessionUuid: aggregate.row.sessionUuid,
+      sessionRef: sessionRefForResult(sourceId, aggregate.row.sessionUuid, aggregate.row.sessionKey),
+      title: aggregate.row.title,
+      summaryText: aggregate.row.summaryText,
+      cwd: aggregate.row.cwd,
+      startedAt: aggregate.row.startedAt,
+      endedAt: aggregate.row.endedAt,
+      matchCount: aggregate.hitCount,
+      matchSource: aggregate.bestDisplayRow.matchSource,
+      matchSeq: aggregate.bestDisplayRow.matchSeq,
+      matchRole: aggregate.bestDisplayRow.matchRole,
+      matchTimestamp: aggregate.bestDisplayRow.matchTimestamp,
+      score: sessionScore,
+      snippet: aggregate.bestDisplayRow.snippet,
+    };
+  });
+}
+
+function sessionRefForResult(sourceId: SessionSourceId, sessionUuid: string, sessionKey?: string): string {
+  if (sourceId === DEFAULT_SESSION_SOURCE_ID) return sessionUuid;
+  return sessionKey ?? `${sourceId}:${sessionUuid}`;
 }
 
 function shouldUseDisplayRow(

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,7 +159,9 @@ export interface MessageRecord {
 
 export interface FindResult {
   rank: number;
+  sourceId: SessionSourceId;
   sessionUuid: string;
+  sessionRef: string;
   title: string;
   summaryText: string;
   cwd: string;
@@ -176,6 +178,7 @@ export interface FindResult {
 
 export interface FindSummary {
   query: string;
+  sourceIds: SessionSourceId[];
   sort: FindSort;
   excludedSessions: string[];
   results: FindResult[];
@@ -183,6 +186,7 @@ export interface FindSummary {
   // "从 ~N 条历史里定位",分母随搜索范围走,不灌水。
   scannedMessageCount: number;
   coverage: CoverageStatus;
+  coverageBySource?: Array<{ sourceId: SessionSourceId; coverage: CoverageStatus }>;
   nextAction?: QueryNextAction;
 }
 


### PR DESCRIPTION
<!-- mainline:pr-description:start -->
## Mainline Intent

**Intent:** `int_2f23b8e6`
**Status:** `proposed`
**Title:** 让 cxs find 默认跨源搜索并无缝读取结果

### What changed

把 CLI 的默认 find 行为从单一 Codex source 改为跨 public sources 搜索，当前覆盖 codex 与 experimental claude-code。结果 JSON 增加 sourceIds、sourceId、sessionRef 和 coverageBySource；text next command 改用 sessionRef；read-range/read-page 在未传 --source 时可直接从 source-qualified sessionRef 推断 source。同时补测试、README、架构文档、coverage design、roadmap、发行 skill references，并把版本 bump 到 0.3.7。

### Why

真实使用验证表明 Agent 默认不会主动思考 source；在 Claude-only 历史存在时，旧的 omitted-source=Codex find 会直接漏召回。用户明确要求真实使用时默认能同时搜到 Codex 和 Claude Code，并且后续 read 不需要再推断来源。

### Decisions

- **默认检索语义:** 只把 find 的省略 source 行为改成跨 public sources；status、sync、list、stats 和裸 read 继续保留 Codex 兼容默认。 (find 是 Agent 的 semantic recall 入口，最需要无缝；其他命令仍是 source-scoped planning、mutation 或 metadata/read 操作，一次性改成跨源会扩大语义和兼容风险。)
  - Rejected: 继续让 omitted-source find 等价于 Codex，让 Agent 自己判断何时切 claude-code。
  - Rejected: 把所有固定命令的省略 source 都改成跨源。
- **跨源排序策略:** CLI 对各 public source 执行单源 find fanout，再用 reciprocal-rank fusion 合并候选。 (不同 source 子集的 raw FTS/bm25 分数不能直接比较；用每个 source 内部 rank 做融合更稳，也保留现有单源 ranking 逻辑。)
  - Rejected: 直接把不同 source 的 raw score 混排。
  - Rejected: 先上更重的 resource-level reranker。
- **read 无缝性:** FindResult 暴露 sourceId 和 sessionRef；read-range/read-page 在 sessionRef 带 source qualifier 时自动推断 source。 (Agent 可以把 find JSON 结果直接传给 read 命令，不再需要从 UUID 或结果来源推断 --source。)
  - Rejected: 只在文本输出里提示 --source claude-code。
  - Rejected: 要求调用方继续拼接 source 参数。
- **coverage 与写入边界:** find 保持只读，跨源结果携带 coverageBySource；零结果 nextAction 指向逐 source 的 status/sync/retry。 (这保留了 sync 是唯一写入口的既有边界，同时让默认跨源 find 能解释哪些 source 覆盖不足。)
  - Rejected: 让 find 隐式触发 sync。
  - Rejected: 在跨源 coverage 不完整时直接隐藏已有结果。

**Subsystems:** README.md, docs, eval, package-lock.json, package.json, skill-packages, src
<!-- mainline:pr-description:end -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `cxs find` search all public indexed sources by default and return source-aware results that can be read directly. This avoids misses when history only exists in Claude Code and simplifies agent handoffs.

- **New Features**
  - `find` now searches `codex` and experimental `claude-code` by default; `--source all` is a synonym. Use `--source codex` or `--source claude-code` to narrow.
  - Cross-source fanout + reciprocal-rank fusion with stable dedupe and ordering.
  - `find --json`: add `sourceIds`, per-result `sourceId` and `sessionRef`, and top-level `coverageBySource`. Zero-result `nextAction` now guides per-source `status/sync`.
  - `read-range`/`read-page` accept `sessionRef` and auto-detect source; CLI suggestions use `sessionRef`. Text output shows `source=...`.
  - Docs and tests updated; bump `@act0r/cxs` to 0.3.7.

- **Migration**
  - Behavior change: pass `--source codex` to `find` to restore the old default.
  - If you consume `find --json`, handle the new fields and prefer `sessionRef` for follow-up reads.
  - `status`, `sync`, `list`, and `stats` still default to Codex when `--source` is omitted; specify `--source` to diagnose coverage per source.

<sup>Written for commit ce1da97912400b02261f8f3ba009d53ed2c3a4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/cxs/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

