### PR TITLE
fix(sources): 修复 Pi 超长首条消息漏索引

### DIFF
--- a/src/sources/pi-inventory.ts
+++ b/src/sources/pi-inventory.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
-import { opendir, open, stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { opendir, stat } from "node:fs/promises";
 import { resolve, sep } from "node:path";
+import { createInterface } from "node:readline";
 import { canonicalizeSelector, selectorContainsFile, selectorSource } from "../selector";
 import type {
   DateRange,
@@ -13,7 +15,7 @@ import type {
 import { SourceInventoryError } from "./codex-inventory";
 import { acceptedPiCompactionRecord, acceptedPiMessageRecord, acceptedPiSessionRecord, timestampDate } from "./pi-policy";
 
-const METADATA_SCAN_BYTES = 64 * 1024;
+const ACCEPTED_METADATA_RECORD_LIMIT = 2;
 
 interface PiSourceFileMeta extends SourceFileMeta {
   acceptedFingerprint: string;
@@ -101,20 +103,16 @@ async function readAcceptedMetadataAsync(filePath: string): Promise<{ cwd: strin
   let pathDate: string | null = null;
   let acceptedCount = 0;
   const hash = createHash("sha256");
-  let fh = null;
+  const input = createReadStream(filePath, { encoding: "utf8" });
 
   try {
-    fh = await open(filePath, "r");
-    const buffer = Buffer.allocUnsafe(METADATA_SCAN_BYTES);
-    const { bytesRead } = await fh.read(buffer, 0, METADATA_SCAN_BYTES, 0);
-    const prefix = buffer.subarray(0, bytesRead).toString("utf8");
-    let cursor = 0;
-    while (cursor < prefix.length) {
-      let end = prefix.indexOf("\n", cursor);
-      if (end === -1) end = prefix.length;
+    const lineReader = createInterface({
+      input,
+      crlfDelay: Infinity,
+    });
 
-      const line = prefix.slice(cursor, end).trim();
-      cursor = end + 1;
+    for await (const rawLine of lineReader) {
+      const line = rawLine.trim();
       if (!line) continue;
 
       let record: Record<string, unknown>;
@@ -147,6 +145,7 @@ async function readAcceptedMetadataAsync(filePath: string): Promise<{ cwd: strin
         hash.update(message.timestamp);
         hash.update("\0");
         hash.update(message.contentText);
+        if (acceptedCount >= ACCEPTED_METADATA_RECORD_LIMIT) break;
         continue;
       }
 
@@ -158,18 +157,13 @@ async function readAcceptedMetadataAsync(filePath: string): Promise<{ cwd: strin
         hash.update(compaction.timestamp);
         hash.update("\0");
         hash.update(compaction.summaryText);
+        if (acceptedCount >= ACCEPTED_METADATA_RECORD_LIMIT) break;
       }
     }
   } catch {
     return null;
   } finally {
-    if (fh !== null) {
-      try {
-        await fh.close();
-      } catch {
-        // Best-effort metadata scan; parser/sync handles real file errors.
-      }
-    }
+    input.destroy();
   }
 
   if (acceptedCount === 0) return null;

--- a/src/sources/pi.test.ts
+++ b/src/sources/pi.test.ts
@@ -333,6 +333,33 @@ describe("pi source adapter", () => {
     expect(foundBeforeResync.results).toEqual([]);
   });
 
+  test("syncs Pi sessions whose first accepted message line exceeds the metadata scan window", async () => {
+    const longNeedle = `first accepted pi long needle ${"x".repeat(70_000)} tail`;
+    const { root } = writePiFixture("long-first-message", [
+      piLine({ type: "session", id: "pi-long-first-session", cwd: "/tmp/pi-long-first-cwd", timestamp: "2026-06-09T00:00:00.000Z" }),
+      piLine({
+        type: "message",
+        timestamp: "2026-06-09T00:00:01.000Z",
+        message: { role: "user", content: [{ type: "text", text: longNeedle }] },
+      }),
+    ]);
+    const dbPath = join(root, "index.sqlite");
+
+    const summary = await syncSessions({
+      dbPath,
+      sourceId: "pi",
+      selector: { source: "pi", kind: "all", root },
+    });
+
+    expect(summary.errors).toBe(0);
+    expect(summary.added).toBe(1);
+    expect(summary.coverage.sourceFileCount).toBe(1);
+    expect(summary.coverage.indexedSessionCount).toBe(1);
+
+    const found = findSessions(dbPath, "first accepted pi long needle", 10, { source: "pi", kind: "all", root }, { sourceId: "pi" });
+    expect(found.results.map((result) => result.sessionUuid)).toEqual(["pi:pi-long-first-session"]);
+  });
+
   test("fallback session ids stay unique when different directories share the same file name", async () => {
     const { root } = writePiFixtureTree("fallback-session-id", [
       {


### PR DESCRIPTION
## Summary

- Fix Pi source inventory so valid sessions are not skipped when the first accepted message line is larger than the old metadata prefix window.
- Replace fixed 64KB prefix parsing with line-based JSONL metadata scanning that stops after a small number of accepted content records.
- Add a regression test for a Pi session whose first accepted user message is over 64KB.

## Root Cause

Pi inventory used a fixed 64KB prefix to decide whether a JSONL file contained accepted message or compaction content. If the first accepted message itself exceeded that prefix, the truncated JSON line failed to parse, `acceptedCount` stayed zero, and sync wrote complete coverage with `sourceFileCount=0`.

## Validation

- `npm test -- src/sources/pi.test.ts` (red before fix, green after fix)
- CLI smoke: `sync --source pi` on a long-first-message fixture returns `scanned=1`, `added=1`, `sourceFileCount=1`, and `find` returns `pi:pi-long-first`
- `npm run check`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Pi inventory skipping when the first accepted message is larger than 64 KB. Switches to streaming, line-based JSONL parsing to correctly index these sessions.

- **Bug Fixes**
  - Replace 64 KB prefix read with streaming line-by-line parsing that stops after 2 accepted records, preventing truncated-line parse failures and computing `acceptedFingerprint` reliably.
  - Add a regression test for a session whose first accepted user message exceeds 64 KB.

<sup>Written for commit afb776acbc851b5aa404b0374c902e650ef7dfd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/sherlog/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

