### PR TITLE
Add evidence-level acceptance eval gate

### DIFF
--- a/eval/acceptance-gate.test.ts
+++ b/eval/acceptance-gate.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { runAcceptanceGate } from "./acceptance-gate";
+
+describe("acceptance gate", () => {
+  test("passes synthetic evidence-level retrieval fixtures", async () => {
+    const result = await runAcceptanceGate();
+
+    expect(result.sync.added).toBe(4);
+    expect(result.scoreboard).toMatchObject({
+      total: 3,
+      pass: 3,
+      fail: 0,
+      hardFail: 0,
+    });
+    expect(result.rows.map((row) => row.id)).toEqual([
+      "message-hit-context",
+      "session-only-compact-context",
+      "cjk-message-hit",
+    ]);
+    expect(result.rows.every((row) => row.predicates.length > 0)).toBe(true);
+  });
+});

--- a/eval/acceptance-gate.ts
+++ b/eval/acceptance-gate.ts
@@ -1,0 +1,241 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { desiredContextMode, evaluateDogfoodItem, type DogfoodEvaluation } from "./dogfood-eval-core";
+import type { DogfoodGolden } from "./dogfood-schema";
+import { syncSessions } from "../src/indexer";
+import { findSessions, getMessagePage, getMessageRange } from "../src/query";
+import type { FindResult, SyncSummary } from "../src/types";
+
+const MESSAGE_HIT_SESSION = "11111111-1111-4111-8111-111111111111";
+const SESSION_HIT_SESSION = "22222222-2222-4222-8222-222222222222";
+const CJK_HIT_SESSION = "33333333-3333-4333-8333-333333333333";
+const NOISE_SESSION = "44444444-4444-4444-8444-444444444444";
+
+export interface AcceptanceGateOptions {
+  keepTemp?: boolean;
+}
+
+export interface AcceptanceGateRow {
+  id: string;
+  query: string;
+  status: DogfoodGolden["status"];
+  mark: DogfoodEvaluation["mark"];
+  blocking: boolean;
+  selectedRank: number | null;
+  selectedSessionRef: string | null;
+  selectedMatchSource: FindResult["matchSource"] | null;
+  selectedMatchSeq: number | null;
+  contextKind?: "read-range" | "read-page";
+  predicates: DogfoodEvaluation["predicateResults"];
+}
+
+export interface AcceptanceGateResult {
+  fixtureRoot: string;
+  dbPath: string;
+  sync: SyncSummary;
+  scoreboard: Record<"total" | "pass" | "fail" | "skip" | "hardFail" | "candidateFail", number>;
+  rows: AcceptanceGateRow[];
+}
+
+export async function runAcceptanceGate(options: AcceptanceGateOptions = {}): Promise<AcceptanceGateResult> {
+  const base = mkdtempSync(join(tmpdir(), "sherlog-acceptance-"));
+  try {
+    const fixtureRoot = join(base, "sessions");
+    const dbPath = join(base, "index.sqlite");
+    writeAcceptanceFixtures(fixtureRoot);
+    const sync = await syncSessions({ dbPath, rootDir: fixtureRoot });
+    const rows = evaluateAcceptanceItems(dbPath, acceptanceGoldens());
+    return { fixtureRoot, dbPath, sync, scoreboard: buildScoreboard(rows), rows };
+  } finally {
+    if (!options.keepTemp) rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function evaluateAcceptanceItems(dbPath: string, items: DogfoodGolden[]): AcceptanceGateRow[] {
+  return items.map((item) => {
+    const limit = Math.max(item.expected.topK ?? 5, item.find?.limit ?? 0, 5);
+    const summary = findSessions(dbPath, item.query, limit, item.find?.selector ?? null, {
+      sort: item.find?.sort,
+      excludeSessions: item.find?.excludeSessionUuids,
+      sourceId: item.expected.sourceId,
+    });
+    const preselected = evaluateDogfoodItem({ item, results: summary.results }).selected;
+    const context = readContextIfNeeded(dbPath, item, preselected.hit);
+    const evaluation = evaluateDogfoodItem({
+      item,
+      results: summary.results,
+      contextText: context.text,
+      contextKind: context.kind,
+      contextUnavailableReason: context.unavailableReason,
+    });
+
+    return {
+      id: item.id,
+      query: item.query,
+      status: item.status,
+      mark: evaluation.mark,
+      blocking: evaluation.blocking,
+      selectedRank: evaluation.selected.rank,
+      selectedSessionRef: evaluation.selected.hit?.sessionRef ?? null,
+      selectedMatchSource: evaluation.selected.hit?.matchSource ?? null,
+      selectedMatchSeq: evaluation.selected.hit?.matchSeq ?? null,
+      ...(context.kind ? { contextKind: context.kind } : {}),
+      predicates: evaluation.predicateResults,
+    };
+  });
+}
+
+function readContextIfNeeded(
+  dbPath: string,
+  item: DogfoodGolden,
+  hit: FindResult | null,
+): { kind?: "read-range" | "read-page"; text?: string; unavailableReason?: string } {
+  const mode = desiredContextMode(item, hit);
+  if (!mode) return {};
+  if (!hit) return { unavailableReason: "no selected hit for context read" };
+  const context = item.expected.context ?? {};
+  if (mode === "read-range") {
+    if (typeof hit.matchSeq !== "number") {
+      return { kind: "read-range", unavailableReason: "selected hit has no numeric matchSeq" };
+    }
+    const range = getMessageRange(dbPath, hit.sessionRef, {
+      seq: hit.matchSeq,
+      before: context.before ?? 2,
+      after: context.after ?? 2,
+    });
+    return { kind: "read-range", text: messagesText(range.messages) };
+  }
+
+  const page = getMessagePage(dbPath, hit.sessionRef, context.offset ?? 0, context.limit ?? 20);
+  return { kind: "read-page", text: messagesText(page.messages) };
+}
+
+function buildScoreboard(rows: AcceptanceGateRow[]): AcceptanceGateResult["scoreboard"] {
+  const scoreboard = { total: rows.length, pass: 0, fail: 0, skip: 0, hardFail: 0, candidateFail: 0 };
+  for (const row of rows) {
+    scoreboard[row.mark] += 1;
+    if (row.status === "hard" && row.mark === "fail") scoreboard.hardFail += 1;
+    if (row.status === "candidate" && row.mark === "fail") scoreboard.candidateFail += 1;
+  }
+  return scoreboard;
+}
+
+function acceptanceGoldens(): DogfoodGolden[] {
+  return [
+    {
+      id: "message-hit-context",
+      query: "health check returned 500",
+      intent: "message hits should identify the exact session and readable range context",
+      status: "hard",
+      expected: {
+        topK: 1,
+        sourceId: "codex",
+        acceptableSessionUuids: [MESSAGE_HIT_SESSION],
+        sessionRef: MESSAGE_HIT_SESSION,
+        cwdContains: "/tmp/sherlog-acceptance/deploy",
+        matchSource: "message",
+        matchSeq: 1,
+        context: {
+          mode: "read-range",
+          before: 1,
+          after: 1,
+          mustContain: ["health check returned 500", "rollback plan includes readback verification"],
+        },
+      },
+    },
+    {
+      id: "session-only-compact-context",
+      query: "durable output queue",
+      intent: "session-level compact recall should still lead to raw transcript context",
+      status: "hard",
+      expected: {
+        topK: 1,
+        sourceId: "codex",
+        acceptableSessionUuids: [SESSION_HIT_SESSION],
+        sessionRef: SESSION_HIT_SESSION,
+        cwdContains: "/tmp/sherlog-acceptance/handoff",
+        matchSource: "session",
+        matchSeq: null,
+        context: {
+          mode: "read-page",
+          offset: 0,
+          limit: 10,
+          mustContain: ["Prepare release notes", "Use the existing checklist"],
+        },
+      },
+    },
+    {
+      id: "cjk-message-hit",
+      query: "回滚预案",
+      intent: "CJK message recall should preserve evidence identity and range context",
+      status: "hard",
+      expected: {
+        topK: 1,
+        sourceId: "codex",
+        acceptableSessionUuids: [CJK_HIT_SESSION],
+        sessionRef: CJK_HIT_SESSION,
+        cwdContains: "/tmp/sherlog-acceptance/cjk",
+        matchSource: "message",
+        matchSeq: 0,
+        context: {
+          mode: "read-range",
+          before: 0,
+          after: 1,
+          mustContain: ["回滚预案", "健康检查恢复"],
+        },
+      },
+    },
+  ];
+}
+
+function writeAcceptanceFixtures(root: string): void {
+  const day = join(root, "2026", "06", "26");
+  mkdirSync(day, { recursive: true });
+  writeCodexSession(day, MESSAGE_HIT_SESSION, "/tmp/sherlog-acceptance/deploy", [
+    event("user_message", "Investigate deploy failure"),
+    event("agent_message", "The health check returned 500 after deploy."),
+    event("user_message", "The rollback plan includes readback verification."),
+  ]);
+  writeCodexSession(day, SESSION_HIT_SESSION, "/tmp/sherlog-acceptance/handoff", [
+    event("user_message", "Prepare release notes"),
+    compacted("handoff says durable output queue needs final verification"),
+    event("agent_message", "Use the existing checklist before publishing."),
+  ]);
+  writeCodexSession(day, CJK_HIT_SESSION, "/tmp/sherlog-acceptance/cjk", [
+    event("user_message", "准备回滚预案"),
+    event("agent_message", "先确认健康检查恢复，再继续发布。"),
+  ]);
+  writeCodexSession(day, NOISE_SESSION, "/tmp/sherlog-acceptance/noise", [
+    event("user_message", "Refactor parser docs"),
+    event("agent_message", "No deploy or handoff evidence here."),
+  ]);
+}
+
+function writeCodexSession(day: string, uuid: string, cwd: string, records: Record<string, unknown>[]): void {
+  const filePath = join(day, `rollout-2026-06-26T05-00-00-${uuid}.jsonl`);
+  const content = [line("session_meta", { id: uuid, cwd }), line("turn_context", { model: "gpt-5.4" }), ...records]
+    .map((record) => JSON.stringify(record))
+    .join("\n");
+  writeFileSync(filePath, content);
+}
+
+function event(type: "user_message" | "agent_message", message: string): Record<string, unknown> {
+  return line("event_msg", { type, message });
+}
+
+function compacted(message: string): Record<string, unknown> {
+  return line("compacted", { message });
+}
+
+function line(type: string, payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    timestamp: "2026-06-26T05:00:00.000Z",
+    type,
+    payload,
+  };
+}
+
+function messagesText(messages: Array<{ role: string; contentText: string }>): string {
+  return messages.map((message) => `${message.role}: ${message.contentText}`).join("\n");
+}

--- a/eval/dogfood-eval-core.test.ts
+++ b/eval/dogfood-eval-core.test.ts
@@ -44,6 +44,21 @@ describe("dogfood eval core", () => {
     expect(evaluation.mark).toBe("pass");
   });
 
+  test("checks source id, session ref, and nullable match sequence", () => {
+    const evaluation = evaluateDogfoodItem({
+      item: golden({ sourceId: "codex", sessionRef: "session-a", matchSource: "session", matchSeq: null }),
+      results: [findResult({ matchSource: "session", matchSeq: null })],
+    });
+
+    expect(evaluation.mark).toBe("pass");
+    expect(evaluation.predicateResults.map((predicate) => predicate.label)).toEqual([
+      "source_id",
+      "session_ref",
+      "match_source",
+      "match_seq",
+    ]);
+  });
+
   test("uses read-range for message hits and read-page for session-only hits in auto mode", () => {
     const item = golden({ contextMustContain: ["decision"] });
 
@@ -72,7 +87,10 @@ describe("dogfood eval core", () => {
       },
       expected: {
         topK: 5,
+        sourceId: "codex",
         acceptableSessionUuids: ["target-session"],
+        sessionRef: "target-session",
+        matchSeq: null,
       },
     }), "goldens.local.jsonl");
 
@@ -90,7 +108,11 @@ describe("dogfood eval core", () => {
 function golden(
   overrides: Partial<{
     status: "candidate" | "hard" | "stale";
+    sourceId: "codex" | "claude-code" | "pi";
     acceptableSessionUuids: string[];
+    sessionRef: string;
+    matchSource: "message" | "session";
+    matchSeq: number | null;
     topK: number;
     contextMustContain: string[];
   }> = {},
@@ -102,7 +124,11 @@ function golden(
     status: overrides.status ?? "hard",
     expected: {
       topK: overrides.topK,
+      sourceId: overrides.sourceId,
       acceptableSessionUuids: overrides.acceptableSessionUuids,
+      sessionRef: overrides.sessionRef,
+      matchSource: overrides.matchSource,
+      matchSeq: overrides.matchSeq,
       context: overrides.contextMustContain ? { mustContain: overrides.contextMustContain } : undefined,
     },
   };

--- a/eval/dogfood-eval-core.ts
+++ b/eval/dogfood-eval-core.ts
@@ -4,7 +4,7 @@ import type { DogfoodGolden } from "./dogfood-schema";
 export type DogfoodMark = "pass" | "fail" | "skip";
 
 export interface DogfoodPredicateResult {
-  label: "session_uuid" | "cwd" | "match_source" | "context";
+  label: "source_id" | "session_uuid" | "session_ref" | "cwd" | "match_source" | "match_seq" | "context";
   expected: string;
   actual: string;
   matched: boolean;
@@ -87,12 +87,30 @@ function buildPredicates(
   const predicates: DogfoodPredicateResult[] = [];
   const acceptable = item.expected.acceptableSessionUuids ?? [];
 
+  if (item.expected.sourceId) {
+    predicates.push({
+      label: "source_id",
+      expected: item.expected.sourceId,
+      actual: hit?.sourceId ?? "no selected hit",
+      matched: hit?.sourceId === item.expected.sourceId,
+    });
+  }
+
   if (acceptable.length > 0) {
     predicates.push({
       label: "session_uuid",
       expected: `one of ${acceptable.join(", ")} in top ${selected.topK}`,
       actual: hit ? `${hit.sessionUuid} at rank ${selected.rank}` : "no results",
       matched: Boolean(hit && acceptable.includes(hit.sessionUuid) && (selected.rank ?? Infinity) <= selected.topK),
+    });
+  }
+
+  if (item.expected.sessionRef) {
+    predicates.push({
+      label: "session_ref",
+      expected: item.expected.sessionRef,
+      actual: hit?.sessionRef ?? "no selected hit",
+      matched: hit?.sessionRef === item.expected.sessionRef,
     });
   }
 
@@ -112,6 +130,15 @@ function buildPredicates(
       expected: item.expected.matchSource,
       actual: hit?.matchSource ?? "no selected hit",
       matched: hit?.matchSource === item.expected.matchSource,
+    });
+  }
+
+  if (item.expected.matchSeq !== undefined) {
+    predicates.push({
+      label: "match_seq",
+      expected: String(item.expected.matchSeq),
+      actual: hit ? String(hit.matchSeq) : "no selected hit",
+      matched: hit?.matchSeq === item.expected.matchSeq,
     });
   }
 

--- a/eval/dogfood-schema.ts
+++ b/eval/dogfood-schema.ts
@@ -1,5 +1,5 @@
 import { canonicalizeSelector } from "../src/selector";
-import type { FindSort, MatchSource, Selector } from "../src/types";
+import { isSessionSourceId, type FindSort, type MatchSource, type Selector, type SessionSourceId } from "../src/types";
 
 export type DogfoodStatus = "candidate" | "hard" | "stale";
 export type DogfoodOriginKind = "observed-user-ask" | "evidence-backed-derived" | "manual";
@@ -23,9 +23,12 @@ export interface DogfoodExpectedContext {
 
 export interface DogfoodExpected {
   topK?: number;
+  sourceId?: SessionSourceId;
   acceptableSessionUuids?: string[];
+  sessionRef?: string;
   cwdContains?: string;
   matchSource?: MatchSource;
+  matchSeq?: number | null;
   context?: DogfoodExpectedContext;
 }
 
@@ -120,14 +123,30 @@ function parseExpected(value: unknown): DogfoodExpected | null {
   const topK = readPositiveInteger(value.topK);
   if (topK) expected.topK = topK;
 
+  if (typeof value.sourceId === "string" && isSessionSourceId(value.sourceId)) {
+    expected.sourceId = value.sourceId;
+  }
+
   const acceptableSessionUuids = readStringArray(value.acceptableSessionUuids);
   if (acceptableSessionUuids) expected.acceptableSessionUuids = acceptableSessionUuids;
+
+  const sessionRef = readNonEmptyString(value, "sessionRef");
+  if (sessionRef) expected.sessionRef = sessionRef;
 
   const cwdContains = readNonEmptyString(value, "cwdContains");
   if (cwdContains) expected.cwdContains = cwdContains;
 
   if (value.matchSource === "message" || value.matchSource === "session") {
     expected.matchSource = value.matchSource;
+  }
+
+  if (Object.hasOwn(value, "matchSeq")) {
+    if (value.matchSeq === null) {
+      expected.matchSeq = null;
+    } else {
+      const matchSeq = readNonNegativeInteger(value.matchSeq);
+      if (typeof matchSeq === "number") expected.matchSeq = matchSeq;
+    }
   }
 
   const context = parseContext(value.context);
@@ -216,9 +235,12 @@ function parseOrigin(value: unknown, _lineNumber: number): DogfoodOrigin | undef
 
 function hasExpectedAssertion(expected: DogfoodExpected): boolean {
   return Boolean(
-    expected.acceptableSessionUuids?.length
+    Boolean(expected.sourceId)
+    || expected.acceptableSessionUuids?.length
+    || Boolean(expected.sessionRef)
     || Boolean(expected.cwdContains)
     || Boolean(expected.matchSource)
+    || expected.matchSeq !== undefined
     || expected.context?.mustContain?.length,
   );
 }

--- a/eval/run-acceptance-eval.ts
+++ b/eval/run-acceptance-eval.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S node --import tsx
+
+import { runAcceptanceGate } from "./acceptance-gate";
+
+const keepTemp = process.argv.includes("--keep-temp");
+const result = await runAcceptanceGate({ keepTemp });
+
+console.log(JSON.stringify(result, null, 2));
+if (result.scoreboard.hardFail > 0) process.exitCode = 1;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "shlog": "tsx ./src/cli.ts",
     "cxs": "npm run shlog --",
     "eval:manual": "tsx ./eval/run-manual-eval.ts",
+    "eval:acceptance": "tsx ./eval/run-acceptance-eval.ts",
     "eval:compare": "tsx ./eval/compare-eval-batches.ts",
     "eval:perf": "tsx ./eval/perf-bench.ts",
     "eval:dogfood": "tsx ./eval/run-dogfood-eval.ts"


### PR DESCRIPTION
Closes #70

## Summary
- Add a public synthetic acceptance gate that creates temporary Codex fixtures, syncs them, runs find/read checks, and evaluates evidence-level predicates.
- Extend dogfood expected assertions with sourceId, sessionRef, and nullable matchSeq.
- Add npm run eval:acceptance and a Vitest gate for message hits, session-only compact hits, and CJK recall.

## Review evidence
- Issue #70 called out that eval/manual-eval-core.ts only checks weak title/cwd/snippet predicates.
- The new gate reuses eval/dogfood-eval-core.ts and strengthens its predicate surface.
- The session-only fixture covers matchSource=session with matchSeq=null and read-page context fallback.

## Verification
- npm run eval:acceptance: passed, 3/3 hard fixtures pass.
- npx vitest run eval/acceptance-gate.test.ts eval/dogfood-eval-core.test.ts: passed, 2 files / 9 tests.
- npm run check: passed, 31 files / 205 tests.

request_id: cxs_implement_issues_prs_20260626T050331Z_api_append

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public acceptance eval gate that verifies evidence-level retrieval (message vs session) by creating temporary Codex fixtures, syncing them, and evaluating stronger predicates. This addresses issue #70 by going beyond weak title/cwd checks to enforce `sourceId`, `sessionRef`, and nullable `matchSeq`.

- **New Features**
  - Added `eval/acceptance-gate.ts` to build synthetic sessions, run `findSessions`, read context (range/page), and score results with a pass/fail scoreboard.
  - New CLI `eval:acceptance` (`eval/run-acceptance-eval.ts`) that outputs JSON and exits non‑zero on hard failures; supports `--keep-temp`.
  - New test `eval/acceptance-gate.test.ts` with three hard fixtures: message hit context, session-only compact context, and CJK message recall.

- **Refactors**
  - Extended dogfood schema and predicates: `sourceId`, `sessionRef`, and nullable `matchSeq`; added `source_id`, `session_ref`, and `match_seq` predicate checks.
  - Improved context selection to auto use read-range for message hits and read-page for session-only hits; updated tests in `eval/dogfood-eval-core.test.ts`.

<sup>Written for commit f40fa32d3f2049ca6894da52cfdf443df72e37a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/sherlog/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

