### PR TITLE
Add deterministic evidence reads to find JSON

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,7 +4,7 @@ import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
-import { openWriteDb } from "./db";
+import { openWriteDb, replaceSession } from "./db";
 import { INDEX_VERSION } from "./env";
 import { syncSessions } from "./indexer";
 
@@ -343,6 +343,95 @@ describe("shlog cli", { timeout: 20_000 }, () => {
     expect(found.exitCode).toBe(0);
     const findPayload = JSON.parse(found.stdout) as { results: Array<{ sessionUuid: string }> };
     expect(findPayload.results[0]?.sessionUuid).toBe("12121212-1212-4212-8212-121212121212");
+  });
+
+  test("find --json gives session-only hits a deterministic raw read-page action", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-cli-session-evidence-"));
+    tempDirs.push(base);
+    const dbPath = join(base, "index.sqlite");
+    const sessionUuid = "82828282-8282-4828-8828-828282828282";
+    const db = openWriteDb(dbPath);
+
+    replaceSession(db, {
+      sessionUuid,
+      filePath: join(base, "session-only.jsonl"),
+      title: "payloadbeacon postmortem outline",
+      summaryText: "",
+      compactText: "",
+      reasoningSummaryText: "",
+      cwd: "/tmp/session-evidence",
+      model: "gpt-5.4",
+      startedAt: "2026-04-24T01:00:00.000Z",
+      endedAt: "2026-04-24T01:00:00.000Z",
+      messages: [
+        {
+          role: "user",
+          contentText: "first raw transcript line without the query token",
+          timestamp: "2026-04-24T01:00:00.000Z",
+          seq: 0,
+          sourceKind: "event_msg",
+        },
+        {
+          role: "assistant",
+          contentText: "second raw transcript line for follow-up evidence",
+          timestamp: "2026-04-24T01:00:30.000Z",
+          seq: 1,
+          sourceKind: "event_msg",
+        },
+      ],
+    }, 1, 1, INDEX_VERSION, "");
+    db.close();
+
+    const found = await runCli(["find", "payloadbeacon", "--db", dbPath, "--json"]);
+    expect(found.exitCode).toBe(0);
+    const payload = JSON.parse(found.stdout) as {
+      results: Array<{
+        sessionUuid: string;
+        matchSource: string;
+        matchSeq: number | null;
+        evidenceRead: {
+          kind: "read-page";
+          reason: string;
+          sourceId: string;
+          sessionRef: string;
+          offset: number;
+          limit: number;
+          argv: string[];
+        };
+      }>;
+    };
+    const result = payload.results[0];
+
+    expect(result?.sessionUuid).toBe(sessionUuid);
+    expect(result?.matchSource).toBe("session");
+    expect(result?.matchSeq).toBeNull();
+    expect(result?.evidenceRead).toMatchObject({
+      kind: "read-page",
+      reason: "session_level_match",
+      sourceId: "codex",
+      sessionRef: sessionUuid,
+      offset: 0,
+      limit: 40,
+    });
+    expect(result?.evidenceRead.argv).toEqual(["shlog", "read-page", sessionUuid, "--offset", "0", "--limit", "40"]);
+
+    const page = await runCli([
+      result?.evidenceRead.kind ?? "read-page",
+      result?.evidenceRead.sessionRef ?? "",
+      "--offset",
+      String(result?.evidenceRead.offset ?? 0),
+      "--limit",
+      "1",
+      "--db",
+      dbPath,
+      "--json",
+    ]);
+    expect(page.exitCode).toBe(0);
+    const pagePayload = JSON.parse(page.stdout) as { messages: Array<{ seq: number; contentText: string }> };
+    expect(pagePayload.messages[0]).toMatchObject({
+      seq: 0,
+      contentText: "first raw transcript line without the query token",
+    });
   });
 
   test("fixed commands reject unsupported --source values before other work", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import {
   statsReadoutEnabled,
 } from "./env";
 import { IndexSchemaUpgradeRequiredError, IndexUnavailableError, listCoverageRecords, withReadDb } from "./db";
+import { buildEvidenceReadAction } from "./evidence-read";
 import { getSessionSourceAdapter, listSessionSourceAdapters } from "./sources";
 
 // One-shot migration from legacy cxs data dirs to the current shlog state dir.
@@ -178,7 +179,14 @@ program
       // 含 better-sqlite3 模块加载;shlog 是一次性进程,所以这就是诚实的端到端。
       const elapsedMs = Math.round(performance.now());
       if (options.json) {
-        console.log(JSON.stringify({ ...result, elapsedMs }, null, 2));
+        console.log(JSON.stringify({
+          ...result,
+          results: result.results.map((findResult) => ({
+            ...findResult,
+            evidenceRead: buildEvidenceReadAction(findResult),
+          })),
+          elapsedMs,
+        }, null, 2));
         return;
       }
       printFindResults(result.query, result.results, result.scannedMessageCount, elapsedMs, statsReadoutEnabled(), result.nextAction);

--- a/src/evidence-read.test.ts
+++ b/src/evidence-read.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { buildEvidenceReadAction } from "./evidence-read";
+
+describe("buildEvidenceReadAction", () => {
+  test("message hits resolve to a bounded read-range command", () => {
+    expect(buildEvidenceReadAction({
+      sourceId: "codex",
+      sessionRef: "11111111-1111-4111-8111-111111111111",
+      matchSeq: 7,
+    })).toEqual({
+      kind: "read-range",
+      reason: "message_match",
+      sourceId: "codex",
+      sessionRef: "11111111-1111-4111-8111-111111111111",
+      seq: 7,
+      before: 2,
+      after: 2,
+      argv: [
+        "shlog",
+        "read-range",
+        "11111111-1111-4111-8111-111111111111",
+        "--seq",
+        "7",
+        "--before",
+        "2",
+        "--after",
+        "2",
+      ],
+    });
+  });
+
+  test("session-only hits resolve to a bounded read-page command", () => {
+    expect(buildEvidenceReadAction({
+      sourceId: "claude-code",
+      sessionRef: "claude-code:session-abc",
+      matchSeq: null,
+    })).toEqual({
+      kind: "read-page",
+      reason: "session_level_match",
+      sourceId: "claude-code",
+      sessionRef: "claude-code:session-abc",
+      offset: 0,
+      limit: 40,
+      argv: ["shlog", "read-page", "claude-code:session-abc", "--offset", "0", "--limit", "40"],
+    });
+  });
+});

--- a/src/evidence-read.ts
+++ b/src/evidence-read.ts
@@ -1,0 +1,71 @@
+import { PROGRAM_NAME } from "./env";
+import type { FindResult, SessionSourceId } from "./types";
+
+const DEFAULT_READ_RANGE_BEFORE = 2;
+const DEFAULT_READ_RANGE_AFTER = 2;
+const DEFAULT_SESSION_PAGE_OFFSET = 0;
+const DEFAULT_SESSION_PAGE_LIMIT = 40;
+
+export type EvidenceReadAction =
+  | {
+      kind: "read-range";
+      reason: "message_match";
+      sourceId: SessionSourceId;
+      sessionRef: string;
+      seq: number;
+      before: number;
+      after: number;
+      argv: string[];
+    }
+  | {
+      kind: "read-page";
+      reason: "session_level_match";
+      sourceId: SessionSourceId;
+      sessionRef: string;
+      offset: number;
+      limit: number;
+      argv: string[];
+    };
+
+export function buildEvidenceReadAction(result: Pick<FindResult, "sourceId" | "sessionRef" | "matchSeq">): EvidenceReadAction {
+  if (result.matchSeq === null) {
+    return {
+      kind: "read-page",
+      reason: "session_level_match",
+      sourceId: result.sourceId,
+      sessionRef: result.sessionRef,
+      offset: DEFAULT_SESSION_PAGE_OFFSET,
+      limit: DEFAULT_SESSION_PAGE_LIMIT,
+      argv: [
+        PROGRAM_NAME,
+        "read-page",
+        result.sessionRef,
+        "--offset",
+        String(DEFAULT_SESSION_PAGE_OFFSET),
+        "--limit",
+        String(DEFAULT_SESSION_PAGE_LIMIT),
+      ],
+    };
+  }
+
+  return {
+    kind: "read-range",
+    reason: "message_match",
+    sourceId: result.sourceId,
+    sessionRef: result.sessionRef,
+    seq: result.matchSeq,
+    before: DEFAULT_READ_RANGE_BEFORE,
+    after: DEFAULT_READ_RANGE_AFTER,
+    argv: [
+      PROGRAM_NAME,
+      "read-range",
+      result.sessionRef,
+      "--seq",
+      String(result.matchSeq),
+      "--before",
+      String(DEFAULT_READ_RANGE_BEFORE),
+      "--after",
+      String(DEFAULT_READ_RANGE_AFTER),
+    ],
+  };
+}


### PR DESCRIPTION
Closes #72.

## Summary

- Adds a small `EvidenceReadAction` helper for `find` hits.
- Extends `find --json` results with an `evidenceRead` object so another agent can deterministically follow up with `read-range` for message hits or `read-page` for session-level hits.
- Keeps the existing top-level command surface unchanged; no new command is added and normal text `find` output is untouched.
- Adds coverage for both the helper mapping and a CLI session-only hit that successfully follows the JSON `read-page` guidance back to raw transcript text.

## Review Evidence

This implements the #72 slice from the deep review:

- `src/query/search.ts:searchSessionHits()` can return session-level hits with `matchSeq = null`.
- `src/format.ts:printFindResults()` already guides text users to `read-page` for session-only hits, but JSON output had no equivalent machine-readable follow-up.
- `src/query/read.ts:getMessagePage()` is the existing raw transcript path for session-level hits, so this stays on the accepted command surface from `AGENTS.md`.

Paper lens: retrieval fidelity and long-horizon stability improve when derived session-level recall has a deterministic route back to raw chronological transcript evidence.

## Verification

- `npx vitest run src/evidence-read.test.ts src/cli.test.ts` -> passed, 2 files / 39 tests
- `npm run check` -> passed, `tsc --noEmit` plus 31 files / 206 tests

request_id: cxs_implement_issues_prs_20260626T050331Z_api_append

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic evidence reads to `find --json`. Each result now includes an `evidenceRead` action so agents can follow up with `read-range` or `read-page` without guessing. Addresses #72.

- New Features
  - Introduced `buildEvidenceReadAction` to map hits to a follow-up: message hits -> `read-range` (before=2, after=2); session-only hits -> `read-page` (offset=0, limit=40) with a ready-to-run `argv`.
  - Wired `evidenceRead` into `find --json` results; no changes to commands or text output.
  - Added tests for the helper and a session-only CLI flow that reads back raw transcript text.

<sup>Written for commit b765fc5811b29deb9217c030f23e1d260e348bdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/sherlog/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

