### PR TITLE
Extend perf bench operation cost telemetry

### DIFF
--- a/eval/perf-bench.ts
+++ b/eval/perf-bench.ts
@@ -1,27 +1,105 @@
 #!/usr/bin/env -S node --import tsx
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { spawn as childSpawn } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { existsSync } from "node:fs";
-import { spawn as childSpawn } from "node:child_process";
 
-interface PerQueryRecord {
-  query: string;
+interface LatencyStats {
   runs: number;
   samplesMs: number[];
   p50Ms: number;
   p95Ms: number;
 }
 
+interface TopHitRecord {
+  sourceId: string;
+  sessionRef: string;
+  matchSource: string;
+  matchSeq: number | null;
+}
+
+interface ReadProbeRecord extends LatencyStats {
+  kind: "read-range" | "read-page";
+  sourceId: string;
+  sessionRef: string;
+  argv: string[];
+  messagesReturned: number;
+  anchorSeq?: number;
+  totalCount?: number;
+}
+
+interface PerQueryRecord extends LatencyStats {
+  query: string;
+  resultCount: number;
+  scannedMessageCount: number;
+  topHit: TopHitRecord | null;
+  readRange: ReadProbeRecord | null;
+  readPage: ReadProbeRecord | null;
+}
+
+interface CoverageCostSummary {
+  statusMs: number;
+  coverageCount: number;
+  freshness: Record<string, number>;
+  staleReasons: Record<string, number>;
+  requestedCoverage: {
+    freshness: string;
+    staleReason: string;
+    sourceFileCount: number;
+    recommendedAction: string;
+  } | null;
+}
+
 interface Report {
   generatedAt: string;
+  sourceId: string;
   dbPath: string;
   rootDir: string;
   sessionCount: number;
+  messageCount: number;
   syncMs: number;
   dbSizeBytes: number;
+  runsPerQuery: number;
+  readRunsPerProbe: number;
+  coverage: CoverageCostSummary;
   perQuery: PerQueryRecord[];
+}
+
+interface FindJsonPayload {
+  scannedMessageCount?: number;
+  results?: Array<{
+    sourceId?: string;
+    sessionRef?: string;
+    matchSource?: string;
+    matchSeq?: number | null;
+  }>;
+}
+
+interface ReadJsonPayload {
+  anchorSeq?: number;
+  totalCount?: number;
+  messages?: unknown[];
+}
+
+interface StatsJsonPayload {
+  sessionCount?: number;
+  messageCount?: number;
+  dbSizeBytes?: number;
+}
+
+interface StatusJsonPayload {
+  coverage?: Array<{
+    freshness?: string;
+    sourceFileSetFingerprint?: string;
+    currentSourceFileSetFingerprint?: string;
+  }>;
+  requestedCoverage?: {
+    freshness?: string;
+    staleReason?: string;
+    sourceFileCount?: number;
+    recommendedAction?: string;
+  };
 }
 
 // Bench query 选取原则:
@@ -40,7 +118,8 @@ const BENCH_QUERIES: string[] = [
   "部署 health check",
 ];
 
-const RUNS_PER_QUERY = 5; // 第 1 次作为 warmup,统计后 4 次
+const DEFAULT_RUNS_PER_QUERY = 5; // 第 1 次作为 warmup,统计后续样本
+const DEFAULT_READ_RUNS_PER_PROBE = 3; // 第 1 次作为 warmup,统计后续样本
 const ROOT = resolve(import.meta.dirname, "..");
 const CLI_ENTRY = resolve(ROOT, "src", "cli.ts");
 const OUT_BASE = resolve(ROOT, "data", "shlog-perf");
@@ -48,27 +127,44 @@ const OUT_BASE = resolve(ROOT, "data", "shlog-perf");
 interface CliArgs {
   root: string;
   db: string;
+  source: string;
   jsonOnly: boolean;
+  runsPerQuery: number;
+  readRunsPerProbe: number;
 }
 
 function parseArgs(argv: string[]): CliArgs {
   let root = join(homedir(), ".codex", "sessions");
   let db = join(tmpdir(), `shlog-perf-${Date.now()}.db`);
+  let source = "codex";
   let jsonOnly = false;
+  let runsPerQuery = DEFAULT_RUNS_PER_QUERY;
+  let readRunsPerProbe = DEFAULT_READ_RUNS_PER_PROBE;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--root") {
       root = resolve(argv[++i] ?? root);
     } else if (a === "--db") {
       db = resolve(argv[++i] ?? db);
+    } else if (a === "--source") {
+      source = argv[++i] ?? source;
+    } else if (a === "--runs") {
+      runsPerQuery = parsePositiveInt(argv[++i], DEFAULT_RUNS_PER_QUERY);
+    } else if (a === "--read-runs") {
+      readRunsPerProbe = parsePositiveInt(argv[++i], DEFAULT_READ_RUNS_PER_PROBE);
     } else if (a === "--json-only") {
       jsonOnly = true;
     } else if (a === "--help" || a === "-h") {
-      console.log("Usage: npm run eval:perf -- [--root <dir>] [--db <path>] [--json-only]");
+      console.log("Usage: npm run eval:perf -- [--source <id>] [--root <dir>] [--db <path>] [--runs <n>] [--read-runs <n>] [--json-only]");
       process.exit(0);
     }
   }
-  return { root, db, jsonOnly };
+  return { root, db, source, jsonOnly, runsPerQuery, readRunsPerProbe };
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -111,9 +207,41 @@ function spawnAndCapture(cmd: string[], cwd: string): Promise<{ stdout: string; 
 async function runOrThrow(cmd: string[]): Promise<RunResult> {
   const r = await run(cmd);
   if (r.exitCode !== 0) {
-    throw new Error(`command failed (exit ${r.exitCode}): ${cmd.join(" ")}\n${r.stderr}`);
+    throw new Error(`command failed (exit ${r.exitCode}): ${cmd.join(" ")}\n${r.stderr || r.stdout}`);
   }
   return r;
+}
+
+async function runJsonOrThrow<T>(cmd: string[]): Promise<{ run: RunResult; payload: T }> {
+  const result = await runOrThrow(cmd);
+  try {
+    return { run: result, payload: JSON.parse(result.stdout) as T };
+  } catch (error) {
+    throw new Error(`command did not emit JSON: ${cmd.join(" ")}\n${String(error)}\n${result.stdout}`);
+  }
+}
+
+async function benchJsonCommand<T>(cmd: string[], runs: number): Promise<{ latency: LatencyStats; payload: T }> {
+  const samplesAll: number[] = [];
+  let payload: T | null = null;
+  for (let i = 0; i < runs; i++) {
+    const result = await runJsonOrThrow<T>(cmd);
+    samplesAll.push(result.run.ms);
+    payload = result.payload;
+  }
+  if (!payload) throw new Error(`no payload produced for command: ${cmd.join(" ")}`);
+  return { latency: latencyStats(samplesAll), payload };
+}
+
+function latencyStats(samplesAll: number[]): LatencyStats {
+  const samples = samplesAll.length > 1 ? samplesAll.slice(1) : samplesAll;
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    runs: samples.length,
+    samplesMs: samplesAll.map((x) => Number(x.toFixed(2))),
+    p50Ms: Number(median(sorted).toFixed(2)),
+    p95Ms: Number(percentile(samples, 0.95).toFixed(2)),
+  };
 }
 
 function median(sorted: number[]): number {
@@ -125,9 +253,9 @@ function median(sorted: number[]): number {
 }
 
 function percentile(samplesMs: number[], p: number): number {
-  // 4 个样本下 p95 数学意义薄弱: 直接取 max 作为 worst-case 近似
+  // 小样本下 p95 数学意义薄弱: 直接取 max 作为 worst-case 近似
   if (samplesMs.length === 0) return 0;
-  if (p >= 0.99) return Math.max(...samplesMs);
+  if (p >= 0.95) return Math.max(...samplesMs);
   const sorted = [...samplesMs].sort((a, b) => a - b);
   const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
   return sorted[idx]!;
@@ -144,6 +272,14 @@ function fmtBytes(n: number): string {
   return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
+function cliCommand(...command: string[]): string[] {
+  return [process.execPath, "--import", "tsx", CLI_ENTRY, ...command];
+}
+
+function publicArgv(cmd: string[]): string[] {
+  return ["shlog", ...cmd.slice(4)];
+}
+
 const stamp = new Date().toISOString().replace(/[:.]/g, "-");
 const outDir = args.jsonOnly ? "" : join(OUT_BASE, stamp);
 if (!args.jsonOnly) {
@@ -151,7 +287,7 @@ if (!args.jsonOnly) {
 }
 
 // 1. sync
-const syncRun = await runOrThrow([process.execPath, "--import", "tsx", CLI_ENTRY, "sync", "--db", args.db, "--root", args.root, "--json"]);
+const syncRun = await runOrThrow(cliCommand("sync", "--source", args.source, "--db", args.db, "--root", args.root, "--json"));
 const syncMs = syncRun.ms;
 let sessionCount = 0;
 try {
@@ -161,46 +297,63 @@ try {
   // 解析失败保持 0
 }
 
-// 2. find x N runs per query
+// 2. coverage/freshness cost
+const statusSelector = JSON.stringify({ source: args.source, kind: "all", root: args.root });
+const statusResult = await runJsonOrThrow<StatusJsonPayload>(cliCommand(
+  "status",
+  "--source",
+  args.source,
+  "--root",
+  args.root,
+  "--selector",
+  statusSelector,
+  "--db",
+  args.db,
+  "--json",
+));
+const coverage = coverageCostSummary(statusResult.run, statusResult.payload);
+
+// 3. find + raw-read probes
 const perQuery: PerQueryRecord[] = [];
 for (const q of BENCH_QUERIES) {
-  const samplesAll: number[] = [];
-  for (let i = 0; i < RUNS_PER_QUERY; i++) {
-    const r = await runOrThrow([process.execPath, "--import", "tsx", CLI_ENTRY, "find", q, "--db", args.db, "--limit", "10", "--json"]);
-    samplesAll.push(r.ms);
-  }
-  // 丢弃首次 warmup
-  const samples = samplesAll.slice(1);
-  const sorted = [...samples].sort((a, b) => a - b);
+  const findCommand = cliCommand("find", q, "--source", args.source, "--db", args.db, "--limit", "10", "--json");
+  const { latency, payload } = await benchJsonCommand<FindJsonPayload>(findCommand, args.runsPerQuery);
+  const topHit = topHitFromFind(payload);
   perQuery.push({
     query: q,
-    runs: samples.length,
-    samplesMs: samplesAll.map((x) => Number(x.toFixed(2))),
-    p50Ms: Number(median(sorted).toFixed(2)),
-    p95Ms: Number(percentile(samples, 0.95).toFixed(2)),
+    ...latency,
+    resultCount: Array.isArray(payload.results) ? payload.results.length : 0,
+    scannedMessageCount: typeof payload.scannedMessageCount === "number" ? payload.scannedMessageCount : 0,
+    topHit,
+    readRange: topHit ? await measureReadRange(topHit) : null,
+    readPage: topHit ? await measureReadPage(topHit) : null,
   });
 }
 
-// 3. stats -> dbSizeBytes
-const statsRun = await runOrThrow([process.execPath, "--import", "tsx", CLI_ENTRY, "stats", "--db", args.db, "--json"]);
+// 4. stats -> db size and indexed counts
+const statsRun = await runJsonOrThrow<StatsJsonPayload>(cliCommand("stats", "--source", args.source, "--db", args.db, "--json"));
 let dbSizeBytes = 0;
-try {
-  const parsed = JSON.parse(statsRun.stdout) as { dbSizeBytes?: number; sessionCount?: number };
-  if (typeof parsed.dbSizeBytes === "number") dbSizeBytes = parsed.dbSizeBytes;
-  if (typeof parsed.sessionCount === "number" && parsed.sessionCount > 0) {
-    sessionCount = parsed.sessionCount;
-  }
-} catch {
-  // 忽略
+let messageCount = 0;
+if (typeof statsRun.payload.dbSizeBytes === "number") dbSizeBytes = statsRun.payload.dbSizeBytes;
+if (typeof statsRun.payload.sessionCount === "number" && statsRun.payload.sessionCount > 0) {
+  sessionCount = statsRun.payload.sessionCount;
+}
+if (typeof statsRun.payload.messageCount === "number") {
+  messageCount = statsRun.payload.messageCount;
 }
 
 const report: Report = {
   generatedAt: new Date().toISOString(),
+  sourceId: args.source,
   dbPath: args.db,
   rootDir: args.root,
   sessionCount,
+  messageCount,
   syncMs: Number(syncMs.toFixed(2)),
   dbSizeBytes,
+  runsPerQuery: args.runsPerQuery,
+  readRunsPerProbe: args.readRunsPerProbe,
+  coverage,
   perQuery,
 };
 
@@ -209,39 +362,169 @@ if (!args.jsonOnly) {
   writeFileSync(join(outDir, "report.md"), buildMarkdown(report));
 }
 
+const readProbes = perQuery.flatMap((row) => [row.readRange, row.readPage].filter((probe): probe is ReadProbeRecord => probe !== null));
 const slowest = [...perQuery].sort((a, b) => b.p95Ms - a.p95Ms)[0];
-console.log(JSON.stringify({
+const slowestRead = [...readProbes].sort((a, b) => b.p95Ms - a.p95Ms)[0];
+const summary = {
   outDir: outDir || null,
+  sourceId: report.sourceId,
   sessionCount,
-  syncMs: Number(syncMs.toFixed(2)),
+  messageCount,
+  syncMs: report.syncMs,
   dbSizeBytes,
+  coverage: report.coverage,
   queryCount: perQuery.length,
+  readProbeCount: readProbes.length,
   slowestQuery: slowest ? { query: slowest.query, p95Ms: slowest.p95Ms } : null,
-}, null, 2));
+  slowestRead: slowestRead ? { kind: slowestRead.kind, p95Ms: slowestRead.p95Ms } : null,
+};
+console.log(JSON.stringify(args.jsonOnly ? report : summary, null, 2));
+
+function topHitFromFind(payload: FindJsonPayload): TopHitRecord | null {
+  const first = payload.results?.[0];
+  if (!first || typeof first.sourceId !== "string" || typeof first.sessionRef !== "string" || typeof first.matchSource !== "string") {
+    return null;
+  }
+  const matchSeq = typeof first.matchSeq === "number" ? first.matchSeq : null;
+  return {
+    sourceId: first.sourceId,
+    sessionRef: first.sessionRef,
+    matchSource: first.matchSource,
+    matchSeq,
+  };
+}
+
+async function measureReadRange(hit: TopHitRecord): Promise<ReadProbeRecord | null> {
+  if (hit.matchSeq === null) return null;
+  const cmd = cliCommand(
+    "read-range",
+    hit.sessionRef,
+    "--source",
+    args.source,
+    "--seq",
+    String(hit.matchSeq),
+    "--before",
+    "2",
+    "--after",
+    "2",
+    "--db",
+    args.db,
+    "--json",
+  );
+  const { latency, payload } = await benchJsonCommand<ReadJsonPayload>(cmd, args.readRunsPerProbe);
+  return {
+    kind: "read-range",
+    sourceId: hit.sourceId,
+    sessionRef: hit.sessionRef,
+    argv: publicArgv(cmd),
+    messagesReturned: Array.isArray(payload.messages) ? payload.messages.length : 0,
+    anchorSeq: typeof payload.anchorSeq === "number" ? payload.anchorSeq : undefined,
+    ...latency,
+  };
+}
+
+async function measureReadPage(hit: TopHitRecord): Promise<ReadProbeRecord> {
+  const cmd = cliCommand(
+    "read-page",
+    hit.sessionRef,
+    "--source",
+    args.source,
+    "--offset",
+    "0",
+    "--limit",
+    "40",
+    "--db",
+    args.db,
+    "--json",
+  );
+  const { latency, payload } = await benchJsonCommand<ReadJsonPayload>(cmd, args.readRunsPerProbe);
+  return {
+    kind: "read-page",
+    sourceId: hit.sourceId,
+    sessionRef: hit.sessionRef,
+    argv: publicArgv(cmd),
+    messagesReturned: Array.isArray(payload.messages) ? payload.messages.length : 0,
+    totalCount: typeof payload.totalCount === "number" ? payload.totalCount : undefined,
+    ...latency,
+  };
+}
+
+function coverageCostSummary(run: RunResult, payload: StatusJsonPayload): CoverageCostSummary {
+  const coverageRows = Array.isArray(payload.coverage) ? payload.coverage : [];
+  const freshness = countBy(coverageRows.map((row) => row.freshness ?? "unknown"));
+  const staleReasons = countBy(coverageRows.map((row) => staleReasonForCoverage(row)));
+  const requested = payload.requestedCoverage;
+  return {
+    statusMs: Number(run.ms.toFixed(2)),
+    coverageCount: coverageRows.length,
+    freshness,
+    staleReasons,
+    requestedCoverage: requested ? {
+      freshness: requested.freshness ?? "unknown",
+      staleReason: requested.staleReason ?? "unknown",
+      sourceFileCount: requested.sourceFileCount ?? 0,
+      recommendedAction: requested.recommendedAction ?? "unknown",
+    } : null,
+  };
+}
+
+function staleReasonForCoverage(row: NonNullable<StatusJsonPayload["coverage"]>[number]): string {
+  if (row.freshness !== "stale") return "none";
+  return row.sourceFileSetFingerprint && row.currentSourceFileSetFingerprint === row.sourceFileSetFingerprint
+    ? "source_content_changed"
+    : "source_set_changed";
+}
+
+function countBy(values: string[]): Record<string, number> {
+  return values.reduce<Record<string, number>>((acc, value) => {
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}
 
 function buildMarkdown(r: Report): string {
   const lines: string[] = [];
   lines.push("# shlog 性能基准报告");
   lines.push("");
   lines.push(`- generated_at: ${r.generatedAt}`);
+  lines.push(`- source: \`${r.sourceId}\``);
   lines.push(`- root: \`${r.rootDir}\``);
   lines.push(`- db: \`${r.dbPath}\``);
   lines.push(`- session_count: ${r.sessionCount}`);
+  lines.push(`- message_count: ${r.messageCount}`);
   lines.push(`- sync_ms: ${r.syncMs.toFixed(1)}`);
   lines.push(`- db_size: ${fmtBytes(r.dbSizeBytes)} (${r.dbSizeBytes} bytes)`);
+  lines.push(`- find_runs_per_query: ${r.runsPerQuery} (first run is warmup when runs > 1)`);
+  lines.push(`- read_runs_per_probe: ${r.readRunsPerProbe} (first run is warmup when runs > 1)`);
   lines.push("");
-  lines.push("## per-query find latency");
+  lines.push("## coverage and freshness cost");
   lines.push("");
-  lines.push(`运行配置: 每个 query ${RUNS_PER_QUERY} 次,丢弃首次 warmup,统计后 ${RUNS_PER_QUERY - 1} 次。`);
-  lines.push("");
-  lines.push("| query | runs | p50 ms | p95 ms | samples (incl. warmup) ms |");
-  lines.push("|-------|-----:|-------:|-------:|---------------------------|");
-  for (const row of r.perQuery) {
-    const samples = row.samplesMs.map((x) => x.toFixed(1)).join(", ");
-    lines.push(`| \`${row.query}\` | ${row.runs} |${fmtMs(row.p50Ms)} |${fmtMs(row.p95Ms)} | ${samples} |`);
+  lines.push(`- status_ms: ${r.coverage.statusMs.toFixed(1)}`);
+  lines.push(`- coverage_count: ${r.coverage.coverageCount}`);
+  lines.push(`- freshness: \`${JSON.stringify(r.coverage.freshness)}\``);
+  lines.push(`- stale_reasons: \`${JSON.stringify(r.coverage.staleReasons)}\``);
+  if (r.coverage.requestedCoverage) {
+    lines.push(`- requested_coverage: \`${JSON.stringify(r.coverage.requestedCoverage)}\``);
   }
   lines.push("");
-  lines.push("> 注: 4 个有效样本下 p95 取最大值作为 worst-case 近似,统计意义有限。");
+  lines.push("## per-query latency and raw-read probes");
+  lines.push("");
+  lines.push("| query | results | scanned msgs | top hit | find p50 ms | find p95 ms | read-range p95 ms | read-page p95 ms |");
+  lines.push("|-------|--------:|-------------:|---------|------------:|------------:|------------------:|----------------:|");
+  for (const row of r.perQuery) {
+    lines.push([
+      `| \`${row.query}\``,
+      row.resultCount.toString(),
+      row.scannedMessageCount.toString(),
+      row.topHit ? `\`${row.topHit.sourceId}/${row.topHit.matchSource}\`` : "-",
+      fmtMs(row.p50Ms),
+      fmtMs(row.p95Ms),
+      row.readRange ? fmtMs(row.readRange.p95Ms) : "-",
+      `${row.readPage ? fmtMs(row.readPage.p95Ms) : "-"} |`,
+    ].join(" | "));
+  }
+  lines.push("");
+  lines.push("> 注: 小样本下 p95 取最大值作为 worst-case 近似;报告只包含计数、耗时、source/session ref 和命令参数,不包含 transcript 内容。");
   lines.push("");
   return lines.join("\n");
 }


### PR DESCRIPTION
Closes #74.

## Summary

- Extends `eval/perf-bench.ts` from sync/find timing into an operation-cost report across sync, status/freshness, find, read-range, read-page, and stats/db-size.
- Adds `--source`, `--runs`, and `--read-runs` options so before/after measurements are repeatable and cheap to smoke test.
- Records source, indexed session/message counts, db size, selector-scoped scanned message counts, coverage freshness/stale-reason summaries, and raw-read probe latency.
- Keeps telemetry local-only. Reports include counts, latency, source/session refs, and command args, but no transcript content.

## Review Evidence

This implements the #74 slice from the deep review:

- `src/cli.ts` already emits elapsed JSON for read/find commands, but the perf script only measured sync and find latency.
- `src/query/stats.ts:collectStats()` exposes session/message counts and db size.
- `src/status.ts:collectStatus()` exposes coverage freshness and requested coverage stale reasons.
- `src/query/read.ts:getMessageRange()` and `src/query/read.ts:getMessagePage()` provide the raw-read operations that were missing from the benchmark.

Paper lens: RQ5 / operation cost. This makes local memory cost visible before heavier retrieval or routing changes.

## Verification

- `npx tsc --noEmit` -> passed
- Synthetic-root smoke test: `npm run eval:perf -- --root <tmp>/sessions --db <tmp>/perf.db --runs 2 --read-runs 2 --json-only` -> passed and produced sync/find/read/status/stats JSON
- `npm run check` -> passed, `tsc --noEmit` plus 30 files / 203 tests

request_id: cxs_implement_issues_prs_20260626T050331Z_api_append

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the perf bench to report per-operation cost across sync, status/freshness, find, raw read-range/page, and stats, with repeatable runs and privacy-safe telemetry. Addresses #74 by making operation cost visible and comparable before deeper changes.

- **New Features**
  - Expanded `eval/perf-bench.ts` to measure p50/p95 and counts for:
    - `sync`, coverage `status` (freshness + stale reasons), `find` (results + scanned messages), `read-range`, `read-page`, and `stats` (db size, session/message counts).
  - Captures top hit per query (source/session/match info) and probes `read-range`/`read-page` on it.
  - New flags: `--source`, `--runs`, `--read-runs` (first run is warmup). Keeps `--json-only`.
  - Output:
    - Writes `report.json` and `report.md`; console prints a short summary unless `--json-only` (then full report).
    - Local-only telemetry: counts, latency, source/session refs, and argv; no transcript content.

- **Migration**
  - No breaking changes. Pass `--source` for your dataset if not using the default.
  - Example: `npm run eval:perf -- --root <path>/sessions --db <path>/perf.db --source codex --runs 5 --read-runs 3 --json-only`

<sup>Written for commit 592c700190523971f6ff3d3242a0e3b711630168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/sherlog/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

