### PR TITLE
Document source adapter projection contracts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,6 +34,8 @@
 - 核心层负责 selector、coverage、DB、query/read/list/stats。
 - `find` 默认跨 public source fanout 并合并结果；切换 `--source claude-code` 或 `--source pi` 时走同一组命令但只查目标 source。当前非 Codex 语义仍限于 allowlisted transcript text。
 
+Accepted/rejected projection boundaries live in [SOURCE_CONTRACTS.md](SOURCE_CONTRACTS.md). Treat that file as the code-facing contract for parser privacy fixtures; it is not an upstream raw-format stability promise.
+
 Codex adapter 会把原有 `sessionUuid` 映射为 source-aware identity：
 
 - `sourceId = "codex"`

--- a/docs/SOURCE_CONTRACTS.md
+++ b/docs/SOURCE_CONTRACTS.md
@@ -1,0 +1,68 @@
+# Source Adapter Contracts
+
+This document describes the searchable projection contract for Sherlog public source adapters. It is not a promise that upstream raw transcript formats are stable. `claude-code` and `pi` remain experimental transcript-reader support until upstream formats and fixtures are stronger.
+
+## Shared Invariants
+
+- Source adapters implement the boundary in `src/sources/types.ts`: root resolution, file collection, inventory, snapshot, and `parseFile`.
+- Indexing stores only accepted transcript projections: session metadata, raw user/assistant text where allowed, and a small set of session-level handoff fields.
+- Unsupported/private records are filtered by default. Tool outputs, attachments, diagnostics, sidechain/meta records, and thinking blocks must not enter `messages_fts` or `sessions_fts` unless a future issue adds an explicit privacy design.
+- Read isolation is source-aware. `sessionRef` values returned by `find` can be passed back to `read-range` or `read-page` without guessing the source.
+- Malformed JSONL records are skipped instead of failing the whole file.
+
+## Codex
+
+Accepted projection:
+
+- `session_meta` id and cwd metadata.
+- `turn_context` model and cwd metadata.
+- `event_msg` records whose payload type is `user_message` or `agent_message` and whose `message` is non-empty text.
+- `compacted` payload text as session-level `compactText`.
+- `response_item` reasoning summaries as session-level `reasoningSummaryText`.
+
+Rejected projection:
+
+- malformed JSONL lines.
+- unrelated record types.
+- `event_msg` records with other payload types, including tool-result-like records.
+- empty user/assistant messages.
+- internal approval/evaluation transcript markers filtered by `looksInternal()`.
+
+## Claude Code
+
+Accepted projection:
+
+- policy-approved user and assistant text records from `claude-code-policy`.
+- accepted session id, cwd, and timestamp metadata only from accepted records.
+
+Rejected projection:
+
+- meta records.
+- sidechain records.
+- tool results.
+- thinking blocks.
+- attachment-like non-text content.
+- skipped records when deriving inventory grouping and snapshots.
+
+## Pi
+
+Accepted projection:
+
+- `session` metadata with id, cwd, and timestamp.
+- latest `model_change` model id.
+- user/assistant text content from `message` records.
+- `compaction` summary text as session-level `compactText`.
+
+Rejected projection:
+
+- tool-result roles.
+- tool-call content.
+- thinking content.
+- unsupported content parts.
+- malformed or incomplete records.
+
+## Current Contract Limits
+
+- The contract covers what Sherlog indexes and reads from synthetic fixtures, not every upstream raw variant.
+- Do not broaden accepted record classes to improve recall without adding privacy-specific tests first.
+- Keep source-specific parser changes paired with negative fixtures that prove private or diagnostic data is still filtered.

--- a/src/sources/codex.test.ts
+++ b/src/sources/codex.test.ts
@@ -60,6 +60,54 @@ describe("codex source adapter", () => {
     expect(parsed.session.sessionUuid).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
     expect(parsed.session.messages[0]?.contentText).toBe("adapter session");
   });
+
+  test("filters unsupported, internal, and malformed Codex records from searchable projection", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-codex-contract-"));
+    tempDirs.push(base);
+    const root = join(base, "sessions");
+    const day = join(root, "2026", "04", "23");
+    mkdirSync(day, { recursive: true });
+    const filePath = join(
+      day,
+      "rollout-2026-04-23T12-00-00-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsonl",
+    );
+    writeFileSync(
+      filePath,
+      [
+        "{not json",
+        line("session_meta", { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", cwd: "/tmp/codex-contract" }),
+        line("event_msg", { type: "tool_result", message: "tool result must not leak" }),
+        line("event_msg", { type: "user_message", message: "accepted codex user text" }),
+        line("event_msg", {
+          type: "user_message",
+          message: "The following is the Codex agent history whose request action you are assessing\ninternal marker must not leak",
+        }),
+        line("event_msg", { type: "agent_message", message: "accepted codex assistant text" }),
+        line("other_record", { message: "unrelated record must not leak" }),
+      ].join("\n"),
+    );
+
+    const parsed = await codexSourceAdapter.parseFile({
+      filePath,
+      cwd: "/tmp/fallback",
+      pathDate: "2026-04-23",
+      mtimeMs: 0,
+      size: 0,
+    });
+
+    expect(parsed.kind).toBe("parsed");
+    if (parsed.kind !== "parsed") return;
+    expect(parsed.session.messages.map((message) => message.contentText)).toEqual([
+      "accepted codex user text",
+      "accepted codex assistant text",
+    ]);
+
+    const searchableProjection = JSON.stringify(parsed.session);
+    expect(searchableProjection).not.toContain("tool result must not leak");
+    expect(searchableProjection).not.toContain("internal marker must not leak");
+    expect(searchableProjection).not.toContain("unrelated record must not leak");
+    expect(searchableProjection).not.toContain("{not json");
+  });
 });
 
 function line(type: string, payload: Record<string, unknown>): string {


### PR DESCRIPTION
Refs #73

## Scope

This PR implements the independent documentation/fixture slice of #73. It does not close #73 because the broader source-aware eval coverage still depends on the #70 acceptance gate work.

## Implementation Summary

- Adds `docs/SOURCE_CONTRACTS.md` as the code-facing contract for accepted vs rejected searchable projection classes across Codex, Claude Code, and Pi source adapters.
- Links that contract from `docs/ARCHITECTURE.md` while preserving the existing experimental-status framing for Claude Code and Pi.
- Adds a Codex parser negative fixture in `src/sources/codex.test.ts` covering malformed JSONL, unsupported records, tool-result-like payloads, and internal transcript markers so they do not enter the searchable session projection.

## Verification

- `npx vitest run src/sources/codex.test.ts` passed: 1 file, 3 tests.
- `npm run check` passed: TypeScript plus 30 test files / 204 tests.
- `git diff --check -- docs/ARCHITECTURE.md docs/SOURCE_CONTRACTS.md src/sources/codex.test.ts` passed.

## Risk

Low. This PR adds documentation and a negative parser fixture only; it does not broaden accepted record types or change indexing behavior.

## Branching / Dependencies

- Base branch: `main`
- Depends on: none
- Merge order: can merge independently of #75, #76, and #77. The remaining #73 eval/parity work should stack on `agent/sherlog-memory-review-stack` after #70/#75 is available there.

request_id: cxs_continue_roadmap_to_completion_20260626T054330Z_api_append

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the searchable projection contract for Codex, Claude Code, and Pi, and adds a Codex negative parser test to enforce privacy filtering. Part of #73; broader source-aware evals still depend on #70.

- **New Features**
  - Added docs/SOURCE_CONTRACTS.md defining accepted vs rejected records per adapter.
  - Linked the contract from docs/ARCHITECTURE.md (keeps Claude Code and Pi as experimental).
  - Added a negative test in src/sources/codex.test.ts to verify malformed JSONL, unsupported records, tool-like payloads, and internal markers are excluded from the searchable projection.

<sup>Written for commit dc7fbc13e80a106b96a1847fc6ac349533225c80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/sherlog/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

