### PR TITLE
fix(status): surface staleReason and advisory on coverage array entries

### DIFF
--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -192,6 +192,64 @@ describe("collectStatus", () => {
     expect(status.requestedCoverage?.recommendedAction).toBe("sync");
   });
 
+  it("returns staleReason on coverage array entries when content changed", async () => {
+    const selector: Selector = { kind: "cwd", root: tempDir, cwd: "/test/project" };
+    const initialSnapshot = await collectSourceSnapshot(selector);
+
+    const db = openWriteDb(dbPath);
+    replaceCoverage(db, selector, initialSnapshot.fingerprint, initialSnapshot.fileSetFingerprint, initialSnapshot.fileCount, 1, INDEX_VERSION);
+    db.close();
+
+    writeFileSync(
+      join(tempDir, "rollout-2023-10-01T12-00-00.jsonl"),
+      [
+        `{"type":"session_meta","payload":{"cwd":"/test/project"}}`,
+        `{"type":"event_msg","payload":{"type":"user_message","message":"active tail"}}`,
+      ].join("\n"),
+    );
+
+    const status = await collectStatus({ rootDir: tempDir, dbPath });
+    expect(status.coverage.length).toBe(1);
+    expect(status.coverage[0].freshness).toBe("stale");
+    expect(status.coverage[0].staleReason).toBe("source_content_changed");
+    expect(status.coverage[0].advisory).toBe(true);
+  });
+
+  it("returns staleReason on coverage array entries when file set changed", async () => {
+    const selector: Selector = { kind: "cwd", root: tempDir, cwd: "/test/project" };
+    const initialSnapshot = await collectSourceSnapshot(selector);
+
+    const db = openWriteDb(dbPath);
+    replaceCoverage(db, selector, initialSnapshot.fingerprint, initialSnapshot.fileSetFingerprint, initialSnapshot.fileCount, 1, INDEX_VERSION);
+    db.close();
+
+    writeFileSync(
+      join(tempDir, "rollout-2023-10-01T13-00-00.jsonl"),
+      `{"type":"session_meta","payload":{"cwd":"/test/project"}}` + "\n",
+    );
+
+    const status = await collectStatus({ rootDir: tempDir, dbPath });
+    expect(status.coverage.length).toBe(1);
+    expect(status.coverage[0].freshness).toBe("stale");
+    expect(status.coverage[0].staleReason).toBe("source_set_changed");
+    expect(status.coverage[0].advisory).toBe(false);
+  });
+
+  it("returns staleReason: none and advisory: false on fresh coverage array entries", async () => {
+    const db = openWriteDb(dbPath);
+    const selector: Selector = { kind: "cwd", root: tempDir, cwd: "/test/project" };
+    const snapshot = await collectSourceSnapshot(selector);
+
+    replaceCoverage(db, selector, snapshot.fingerprint, snapshot.fileSetFingerprint, snapshot.fileCount, 1, INDEX_VERSION);
+    db.close();
+
+    const status = await collectStatus({ rootDir: tempDir, dbPath });
+    expect(status.coverage.length).toBe(1);
+    expect(status.coverage[0].freshness).toBe("fresh");
+    expect(status.coverage[0].staleReason).toBe("none");
+    expect(status.coverage[0].advisory).toBe(false);
+  });
+
   it("calculates requestedCoverage correctly when requested selector has missing coverage", async () => {
     const db = openWriteDb(dbPath);
     db.close();

--- a/src/status.ts
+++ b/src/status.ts
@@ -172,9 +172,17 @@ async function toCoverageInventoryStatus(
     && (record.sourceFileSetFingerprint === "" || snapshot.fileSetFingerprint === record.sourceFileSetFingerprint)
     && snapshot.fileCount === record.sourceFileCount
     && isCurrentIndexVersion(record.indexVersion);
+  const staleReason: CoverageInventoryStatus["staleReason"] = fresh
+    ? "none"
+    : record.sourceFileSetFingerprint !== "" && snapshot.fileSetFingerprint === record.sourceFileSetFingerprint
+      ? "source_content_changed"
+      : "source_set_changed";
+  const advisory = !fresh && isAdvisorySourceContentStale(record.selector, staleReason);
   return {
     ...record,
     freshness: fresh ? "fresh" : "stale",
+    staleReason,
+    advisory,
     currentSourceFingerprint: snapshot.fingerprint,
     currentSourceFileSetFingerprint: snapshot.fileSetFingerprint,
     currentSourceFileCount: snapshot.fileCount,

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,8 @@ export interface CoverageRecord {
 
 export interface CoverageInventoryStatus extends CoverageRecord {
   freshness: "fresh" | "stale";
+  staleReason: "none" | "source_content_changed" | "source_set_changed";
+  advisory: boolean;
   currentSourceFingerprint: string;
   currentSourceFileSetFingerprint: string;
   currentSourceFileCount: number;


### PR DESCRIPTION
<!-- mainline:pr-comment:v1 -->

## Mainline Intent

**Intent:** `int_d9348025`
**Status:** `proposed`
**Title:** Surface staleReason and advisory on coverage array entries

### What changed

Add staleReason ('none' | 'source_content_changed' | 'source_set_changed') and advisory boolean to CoverageInventoryStatus. Compute them in toCoverageInventoryStatus using the same logic as requestedCoverageStaleReason, plus isAdvisorySourceContentStale for the advisory flag. Add 3 RED-then-GREEN tests covering fresh, content-changed, and file-set-changed scenarios.

### Why

Coverage array entries only had freshness: 'fresh' | 'stale' with no staleReason. 6/6 dogfood agents reported coverage warnings as noise because they couldn't distinguish advisory stale (content changed, query still safe) from real stale (file set changed, needs sync). Real data showed 51/53 codex coverage entries stale, but only 1 was advisory and 50 were real — agents had no way to tell without the staleReason field.

### Decisions

- **Where to compute staleReason for array entries:** Inline in toCoverageInventoryStatus, reusing the fileSetFingerprint comparison logic from requestedCoverageStaleReason (The logic is simple enough to inline (3 lines) and avoids extracting a shared function that would be over-engineering for now. The existing requestedCoverageStaleReason covers 'missing' which doesn't apply to array entries (they exist by definition).)
  - Rejected: Extract a shared staleReasonForRecord helper used by both toCoverageInventoryStatus and requestedCoverageStaleReason — rejected because the 'missing' case only applies to requestedCoverage, making the shared function awkward
- **Whether to add advisory field or just staleReason:** Add both staleReason and advisory (staleReason gives the raw reason; advisory gives the actionable conclusion (should I sync or not). Agents reading JSON can check advisory directly without re-implementing the isAdvisorySourceContentStale logic (which is codex-specific today).)
  - Rejected: Only add staleReason and let consumers compute advisory — rejected because isAdvisorySourceContentStale is a source-specific policy that consumers shouldn't need to duplicate

**Subsystems:** src


## Verification

- `npm run check`: 215/215 tests pass (3 new tests in `status.test.ts`)
- Real data (4566 sessions / 247K messages): 53 coverage entries now distinguish 1 advisory (content changed, query safe) from 50 real stale (file set grew, needs sync)

```json
// Before: all entries only had freshness
{"freshness": "stale", ...}  // can't tell if advisory or real

// After: entries have staleReason and advisory
{"freshness": "stale", "staleReason": "source_content_changed", "advisory": true, ...}   // keep querying
{"freshness": "stale", "staleReason": "source_set_changed", "advisory": false, ...}       // needs sync
```

Fixes #84.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add staleReason and advisory to coverage entries so users can tell advisory content changes from real file-set changes and act correctly. This reduces noisy coverage warnings and clarifies when a sync is needed.

- New Features
  - Added staleReason: 'none' | 'source_content_changed' | 'source_set_changed' to CoverageInventoryStatus.
  - Added advisory boolean; computed via isAdvisorySourceContentStale when entry is stale.
  - Compute both in toCoverageInventoryStatus using snapshot and file-set fingerprint checks.
  - Added tests for fresh, content-changed (advisory), and set-changed (needs sync).

<sup>Written for commit 9f94e6bf28ad9462100e8a5c78529b42ebf770c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/catoncat/sherlog/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

