### PR TITLE
chore: dogfood path truth fix + perf bench measures the fresh probe by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ CLI 改动需要对外生效时，走正式发布流程：bump `package.json` �
 Dogfood golden 是开发者本机的真实历史检索验收集，不是普通用户功能。
 
 - 通用 runner / schema 可以维护在 `eval/`，例如 `npm run eval:dogfood -- <goldens.local.jsonl>`
-- 私有 golden 默认放在 ignored 路径：`data/sherlog-dogfood/goldens.local.jsonl`
+- 私有 golden 默认放在 ignored 路径：`data/cxs-dogfood/goldens.local.jsonl`
 - 添加 / promote dogfood golden 只能在用户显式触发 dev-only skill 时进行
 - dev-only skill 源码在仓库内：`dev/skills/sherlog-dogfood/source.md`；本机安装路径 `~/.agents/skills/sherlog-dogfood/SKILL.md` 应通过 `scripts/install-dev-skills.sh` 指向该源码文件
 - 不要把 dogfood capture 流程或私有 golden 放进 `skill-packages/sherlog`
@@ -121,7 +121,7 @@ Dogfood golden 是开发者本机的真实历史检索验收集，不是普通�
 
 用户让 agent 根据 dogfood test 改进 Sherlog 时，先复现和分层，不要直接改实现：
 
-1. 运行 `npm run eval:dogfood -- data/sherlog-dogfood/goldens.local.jsonl`
+1. 运行 `npm run eval:dogfood -- data/cxs-dogfood/goldens.local.jsonl`
 2. 对失败 case 用 `npm run shlog -- find ... --json`、`npm run shlog -- read-range ... --json` 或 `npm run shlog -- read-page ... --json` 复现
 3. 先判断问题层级：
    - index/coverage stale → 修同步/selector 使用流程，不改排序代码

--- a/dev/skills/sherlog-dogfood/source.md
+++ b/dev/skills/sherlog-dogfood/source.md
@@ -90,7 +90,7 @@ Repo: /Users/envvar/work/repos/cxs
 Case: <id> (<status>)
 Symptom: <recall-miss|ranking-wrong|context-wrong|selector-coverage|skill-guidance>
 Original ask/query: <verbatim or derived query>
-Eval command: npm run eval:dogfood -- data/sherlog-dogfood/goldens.local.jsonl
+Eval command: npm run eval:dogfood -- data/cxs-dogfood/goldens.local.jsonl
 Focused repro (in-dev CLI from repo checkout):
 - npm run shlog -- find "<query>" --limit 10 --json
 - npm run shlog -- read-range/read-page ...
@@ -120,7 +120,7 @@ If the user says to fix in the same chat, switch to the repo workflow:
 - Normal coding agents may run existing dogfood gates, but must not add new golden cases unless this skill was explicitly triggered.
 - New cases default to `status: "candidate"`.
 - Promote to `status: "hard"` only when the user explicitly asks to promote that case.
-- Store private examples in ignored local data, normally `/Users/envvar/work/repos/cxs/data/sherlog-dogfood/goldens.local.jsonl`.
+- Store private examples in ignored local data, normally `/Users/envvar/work/repos/cxs/data/cxs-dogfood/goldens.local.jsonl`.
 - Never commit private dogfood examples. Never place them in `skill-packages/sherlog` or repo-local `.agents/skills`.
 - Do not add a dogfood case for an agent mistake if the underlying shlog CLI behaved correctly; record it as a skill-guidance note or ask whether the user wants a skill/doc fix instead.
 
@@ -161,7 +161,7 @@ If the user says to fix in the same chat, switch to the repo workflow:
 5. Append one JSON object per line to:
 
    ```text
-   data/sherlog-dogfood/goldens.local.jsonl
+   data/cxs-dogfood/goldens.local.jsonl
    ```
 
    Candidate template:
@@ -173,7 +173,7 @@ If the user says to fix in the same chat, switch to the repo workflow:
 6. Verify immediately:
 
    ```bash
-   npm run eval:dogfood -- data/sherlog-dogfood/goldens.local.jsonl
+   npm run eval:dogfood -- data/cxs-dogfood/goldens.local.jsonl
    ```
 
    Candidate failures are reported but should not block normal development. Hard failures are blocking.
@@ -188,7 +188,7 @@ Only run when the user explicitly asks to promote a specific case.
 4. Re-run:
 
    ```bash
-   npm run eval:dogfood -- data/sherlog-dogfood/goldens.local.jsonl
+   npm run eval:dogfood -- data/cxs-dogfood/goldens.local.jsonl
    ```
 
 5. Report the case id, selected session, context mode, and final pass/fail.

--- a/eval/perf-bench.ts
+++ b/eval/perf-bench.ts
@@ -176,6 +176,7 @@ interface CliArgs {
   runsPerQuery: number;
   readRunsPerProbe: number;
   dogfoodPath: string | null;
+  bestEffortSync: boolean;
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -186,6 +187,7 @@ function parseArgs(argv: string[]): CliArgs {
   let runsPerQuery = DEFAULT_RUNS_PER_QUERY;
   let readRunsPerProbe = DEFAULT_READ_RUNS_PER_PROBE;
   let dogfoodPath: string | null = null;
+  let bestEffortSync = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--root") {
@@ -200,14 +202,16 @@ function parseArgs(argv: string[]): CliArgs {
       readRunsPerProbe = parsePositiveInt(argv[++i], DEFAULT_READ_RUNS_PER_PROBE);
     } else if (a === "--dogfood") {
       dogfoodPath = resolve(argv[++i] ?? "");
+    } else if (a === "--best-effort") {
+      bestEffortSync = true;
     } else if (a === "--json-only") {
       jsonOnly = true;
     } else if (a === "--help" || a === "-h") {
-      console.log("Usage: npm run eval:perf -- [--source <id>] [--root <dir>] [--db <path>] [--runs <n>] [--read-runs <n>] [--dogfood <goldens.jsonl>] [--json-only]");
+      console.log("Usage: npm run eval:perf -- [--source <id>] [--root <dir>] [--db <path>] [--runs <n>] [--read-runs <n>] [--dogfood <goldens.jsonl>] [--best-effort] [--json-only]");
       process.exit(0);
     }
   }
-  return { root, db, source, jsonOnly, runsPerQuery, readRunsPerProbe, dogfoodPath };
+  return { root, db, source, jsonOnly, runsPerQuery, readRunsPerProbe, dogfoodPath, bestEffortSync };
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -339,7 +343,13 @@ if (!args.jsonOnly) {
 }
 
 // 1. sync
-const syncRun = await runOrThrow(cliCommand("sync", "--source", args.source, "--db", args.db, "--root", args.root, "--best-effort", "--json"));
+// Default to strict sync so coverage is actually written and the status
+// probe below measures the fresh path (the one agents hit in practice).
+// --best-effort used to be hardcoded here, which made the bench manufacture
+// its own stale coverage and permanently report the stale-probe cost.
+const syncCmd = ["sync", "--source", args.source, "--db", args.db, "--root", args.root];
+if (args.bestEffortSync) syncCmd.push("--best-effort");
+const syncRun = await runOrThrow(cliCommand(...syncCmd, "--json"));
 const syncMs = syncRun.ms;
 let sessionCount = 0;
 try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two small fixes surfaced by the v0.4.0 local validation (no CLI behavior change, no release needed):

1. **Dogfood golden path drift**: AGENTS.md and the dev skill said `data/sherlog-dogfood/goldens.local.jsonl`, but the actual maintainer-local path is `data/cxs-dogfood/goldens.local.jsonl` (validated on the maintainer machine, currently bridged by a symlink). Docs now match reality; both paths are covered by the `data/` gitignore.

2. **`eval:perf` stale-probe bias**: the bench hardcoded `--best-effort` sync, which never writes coverage, so the status probe permanently measured the stale path (993ms in the June-vs-now comparison instead of the ~567ms fresh probe agents actually hit). Strict sync is now the default; `--best-effort` remains as an explicit flag.

Verification: `tsc --noEmit` clean; bench smoke on a synthetic 800-file fixture now reports `requestedCoverage: fresh` by default.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88313d36-3cdc-4cfa-b04a-e0804e89d72b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88313d36-3cdc-4cfa-b04a-e0804e89d72b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

