### PR TITLE
perf(status): keep coverage proof off the body SQLite index

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Codex adapter 会把原有 `sessionUuid` 映射为 source-aware identity：
 
 ### 1. 同步
 
-[status.ts](../src/status.ts) 返回执行上下文、compact source inventory、index 状态，以及 `--selector`/`--cwd` 时的 `requestedCoverage` 证明。默认不 dump 历史 `coverage[]` 或 `cwdGroups`（`--inventory` 才做逐行审计）。它可以扫描 raw sessions 的 metadata，但不回答内容问题。一次调用只打开一次 SQLite，并且只对 covering selector 做 snapshot，不重放历史 cwd/date_range 行。
+[status.ts](../src/status.ts) 返回执行上下文、compact source inventory、index 状态，以及 `--selector`/`--cwd` 时的 `requestedCoverage` 证明。默认不 dump 历史 `coverage[]` 或 `cwdGroups`（`--inventory` 才做逐行审计）。它可以扫描 raw sessions 的 metadata，但不回答内容问题。coverage / index counts / file-meta cache 来自 sync 写在 `index.sqlite` 旁的 `index.meta.json` sidecar；sidecar 的 db identity（sqlite+wal mtime/size）与当前文件一致时，`status` 不打开正文库。sidecar 缺失或 identity 不匹配时回退一次只读 SQLite。探测只对 covering selector 做 snapshot，不重放历史 cwd/date_range 行。
 
 [indexer.ts](../src/indexer.ts) 按显式 selector 扫描选定 source 的 session snapshot。当前公开 source 可以是 Codex、Claude Code 或 Pi；增量判断仍基于文件 `mtime`、`size` 和 `indexVersion`。
 
@@ -82,9 +82,9 @@ strict sync 默认只更新当前 source snapshot 中仍可见的文件，并保
 
 SQLite 访问层当前已经按 reader / writer 分流：
 
-- `sync` 走 writer 连接，负责 schema ensure、WAL 初始化与写入事务
-- `find` / `read-range` / `read-page` / `list` / `stats` 走只读连接
-- `status` 不写 index；它可以读取 raw metadata 和只读 SQLite
+- `sync` 走 writer 连接，负责 schema ensure、WAL 初始化、写入事务，并在同一把 sync lock 内把 coverage / counts / file-meta 投影到 `index.meta.json`
+- `find` / `read-range` / `read-page` / `list` / `stats` 走只读连接；`find` 的 coverage 证明优先读 sidecar，FTS 仍读 SQLite
+- `status` 不写 index；它读 raw metadata 和 sidecar，只在 sidecar 不可用时打开只读 SQLite
 - 读路径默认设置 `busy_timeout`，避免并发 agent 多查时把瞬时锁竞争直接暴露成 `SQLITE_BUSY`
 - `sync` 额外有文件级 single-writer lock；遇到活跃 writer 会等待，遇到 dead pid 残留锁会自动清理
 
@@ -107,7 +107,7 @@ CLI 默认 `find` 会对 public sources 执行单源 `findSessions()` fanout，�
 
 每个 find 结果还带 additive recall-packet 字段：`matchedFields`（best-effort 命中出处：message 或 title/summary/compact/reasoningSummary）与 `sessionMessageCount`（该 session 已索引消息总数，作为 read-page 成本上限）。零结果时 CLI 附加 `zeroResults` 诊断：`fresh_miss` / `stale_or_missing_coverage` / `coverage_not_confirmed` 三类 reason，加确定性放宽建议（单个独特 ASCII 标识符、完整 CJK 词串——严格宽于自动形态学放宽已重试过的 AND 组合）。只读命令不会因此隐式 sync。
 
-find/status 的 coverage freshness 探测会复用 sync 写入的 `source_file_meta_cache`（内容派生的 cwd/pathDate/accepted fingerprint，按 file_path + mtime + size 校验）：未变更文件跳过 per-file 内容前缀读取，新文件或已变更文件回退到正常内容扫描。缓存只由 `sync` 写入；缓存值来自与 coverage 指纹同一次扫描，因此命中时快照指纹逐字节一致。探测只对 requested selector 的 covering records（`selectorImplies`）做 snapshot，不把历史 cwd/date_range coverage 行当成审计日志重放。
+find/status 的 coverage freshness 探测会复用 sync 写入的 sidecar（以及 SQLite 回退路径上的 `source_file_meta_cache`）：内容派生的 cwd/pathDate/accepted fingerprint 按 file_path + mtime + size 校验，未变更文件跳过 per-file 内容前缀读取，新文件或已变更文件回退到正常内容扫描。sidecar 与 cache 只由 `sync` 写入；缓存值来自与 coverage 指纹同一次扫描，因此命中时快照指纹逐字节一致。探测只对 requested selector 的 covering records（`selectorImplies`）做 snapshot，不把历史 cwd/date_range coverage 行当成审计日志重放。
 
 `messages` 仍然只代表可回读的真实 transcript。session-level 命中会以 `matchSource = "session"` 返回；如果没有真实 message anchor，`matchSeq` 为 `null`，CLI 会建议先 `read-page`。
 

--- a/docs/COLD_RETENTION.md
+++ b/docs/COLD_RETENTION.md
@@ -42,7 +42,7 @@
 | 层 | 是什么 | 典型位置 | 干什么 |
 | --- | --- | --- | --- |
 | L0 hot | Codex 正在用的 raw | `~/.codex/sessions` | 默认同步源；保持精简 |
-| L1 index | Sherlog SQLite | `~/.local/state/shlog/index.sqlite` | **检索真相源** |
+| L1 index | Sherlog SQLite + metadata sidecar | `~/.local/state/shlog/index.sqlite`（检索真相源）与 `index.meta.json`（status/coverage 元数据平面） | **检索真相源** |
 | L2 cold | 归档 raw（可压缩） | `~/.codex/archived_sessions/.../*.jsonl.zst` | 省空间；证明“还在” |
 | L3 backup | 整包 tar 等 | 任意 | 离线备份；**不**进 prune 语义 |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -92,7 +92,10 @@ By default, source-scoped commands read Codex sessions from `~/.codex/sessions`.
 
 ```text
 ~/.local/state/shlog/index.sqlite
+~/.local/state/shlog/index.meta.json
 ```
+
+`index.sqlite` is the retrieval source of truth. `index.meta.json` is a sync-written metadata sidecar (coverage fingerprints, session/message counts, source file meta cache). `status` and `find` coverage proofs read the sidecar when its sqlite+wal identity still matches; they open the body database only when the sidecar is missing or stale. Sync remains the only writer.
 
 `$XDG_STATE_HOME` is respected, and `SHLOG_DATA_DIR` has the highest priority. `CXS_DATA_DIR` still works as a legacy alias:
 
@@ -107,7 +110,7 @@ Sync is strict by default. If any selected file fails to parse or write, `sync` 
 Sherlog treats three layers as distinct:
 
 1. **Hot raw** — default Codex root `~/.codex/sessions` (what normal `sync` scans)
-2. **Index** — `~/.local/state/shlog/index.sqlite` (retrieval source of truth)
+2. **Index** — `~/.local/state/shlog/index.sqlite` (retrieval source of truth) plus `index.meta.json` (status/coverage metadata plane)
 3. **Cold raw** — e.g. `~/.codex/archived_sessions/.../rollout-*.jsonl.zst` (space saving; not the default sync root)
 
 Recommended space-saving flow:

--- a/skill-packages/sherlog/SKILL.md
+++ b/skill-packages/sherlog/SKILL.md
@@ -18,7 +18,7 @@ description: "Use proactively for local agent-session history and prior setup ar
 | metadata projection：最早/最新、数量、分布、cwd/session 清单、大 session | 只读 SQLite 查询 index 的 `sessions` 表；必要时 `list` | metadata 候选完整；涉及内容时已再用 `read-*` 验证 |
 | semantic recall：主题、关键词、历史配置考古 | `find <query> --json`；按需加 `--cwd/--root/--selector` | 已执行结果的 `evidenceRead.argv`，不只看 title/snippet |
 | context reading：已知 `sessionRef` / seq | `read-range` 或 `read-page` | 已读足够上下文回答问题 |
-| coverage / freshness / index availability | `status --selector/--cwd --json` | 已按 `requestedCoverage.recommendedAction` 决定 query 或同范围 sync。默认不要读 `coverage[]` / `cwdGroups`；审计才用 `--inventory` |
+| coverage / freshness / index availability | `status --selector/--cwd --json` | 已按 `requestedCoverage.recommendedAction` 决定 query 或同范围 sync。默认不要读 `coverage[]` / `cwdGroups`；审计才用 `--inventory`。status 读 sidecar，不打开正文库 |
 | mutation：建索引或更新 coverage | bare `sync`（first-install Codex bootstrap）或 scoped `sync` | sync 无未解决 error；cold 迁移已注册 cold root |
 
 ## Canonical policy

--- a/skill-packages/sherlog/references/cli-surface.md
+++ b/skill-packages/sherlog/references/cli-surface.md
@@ -16,7 +16,7 @@
 
 ## status
 
-Purpose：执行上下文、compact source inventory、index 与 coverage proof。不回答内容，不写状态。默认 JSON 是小证明（`requestedCoverage` + compact index/inventory），不是历史 `coverage[]` / `cwdGroups` 审计。
+Purpose：执行上下文、compact source inventory、index 与 coverage proof。不回答内容，不写状态。默认 JSON 是小证明（`requestedCoverage` + compact index/inventory），不是历史 `coverage[]` / `cwdGroups` 审计。coverage 证明读 sync 写的 `index.meta.json` sidecar，不打开正文库；sidecar 缺失或与 sqlite identity 不一致时才回退只读 SQLite。
 
 ```bash
 "${SHLOG_BIN:-${CXS_BIN:-shlog}}" status --json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,13 +16,10 @@ import {
   removeColdRoot,
 } from "./cold-roots";
 import {
-  buildSourceFileMetaResolver,
   IndexSchemaUpgradeRequiredError,
   IndexUnavailableError,
-  listCoverageRecords,
-  loadSourceFileMetaCache,
-  withReadDb,
 } from "./db";
+import { loadIndexMetadata } from "./index-sidecar";
 import {
   createCachedSnapshotter,
   emptyCoverageProbeStats,
@@ -746,13 +743,11 @@ async function assessFindCoverage(
   const source = getSessionSourceAdapter(sourceId);
   const stats = emptyCoverageProbeStats();
   const dbStarted = performance.now();
-  // Load the sync-written file-meta cache alongside coverage records so the
-  // freshness probe can skip content prefix reads for unchanged files.
-  const { coverageRecords, metaResolver } = withReadDb(dbPath, (db) => ({
-    coverageRecords: listCoverageRecords(db, sourceId),
-    metaResolver: buildSourceFileMetaResolver(loadSourceFileMetaCache(db, sourceId)),
-  }));
-  stats.dbOpens = 1;
+  // Coverage proof reads the sync-written sidecar when its db identity
+  // still matches. find still opens SQLite for FTS; this probe does not.
+  const metadata = loadIndexMetadata(dbPath, sourceId);
+  const { coverageRecords, metaResolver } = metadata;
+  stats.dbOpens = metadata.opened ? 1 : 0;
   stats.dbMs = performance.now() - dbStarted;
   const collectStarted = performance.now();
   const files = await source.collectFiles(selector.root, { metaResolver });

--- a/src/index-sidecar.test.ts
+++ b/src/index-sidecar.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getLastCoverageProbeStats } from "./coverage-freshness";
+import { INDEX_VERSION } from "./env";
+import {
+  indexSidecarPathForDb,
+  loadIndexMetadata,
+  readIndexSidecar,
+} from "./index-sidecar";
+import { syncSessions } from "./indexer";
+import { collectStatus } from "./status";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("index sidecar", () => {
+  test("maps index.sqlite to index.meta.json beside the body database", () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-sidecar-path-"));
+    tempDirs.push(base);
+    expect(indexSidecarPathForDb(join(base, "index.sqlite"))).toBe(join(base, "index.meta.json"));
+    expect(indexSidecarPathForDb(join(base, "test.db"))).toBe(join(base, "test.meta.json"));
+  });
+
+  test("sync writes a sidecar that status uses without opening SQLite", async () => {
+    const { root, dbPath } = writeCodexFixture("sidecar-hit");
+
+    await syncSessions({ dbPath, selector: { kind: "all", root } });
+
+    const sidecarPath = indexSidecarPathForDb(dbPath);
+    expect(existsSync(sidecarPath)).toBe(true);
+    const sidecar = readIndexSidecar(dbPath);
+    expect(sidecar?.version).toBe(1);
+    expect(sidecar?.indexVersion).toBe(INDEX_VERSION);
+    expect(sidecar?.sources.codex?.coverageRecords).toHaveLength(1);
+    expect(sidecar?.sources.codex?.fileMeta).toHaveLength(1);
+    expect(sidecar?.sources.codex?.sessionCount).toBe(1);
+
+    const status = await collectStatus({
+      rootDir: root,
+      dbPath,
+      selector: { kind: "all", root },
+    });
+    const probe = getLastCoverageProbeStats();
+
+    expect(status.requestedCoverage?.freshness).toBe("fresh");
+    expect(status.index.exists).toBe(true);
+    expect(status.index.sessionCount).toBe(1);
+    expect(status.coverageCount).toBe(1);
+    expect(probe?.dbOpens).toBe(0);
+  });
+
+  test("missing sidecar falls back to opening SQLite with the same proof", async () => {
+    const { root, dbPath } = writeCodexFixture("sidecar-missing");
+    await syncSessions({ dbPath, selector: { kind: "all", root } });
+    rmSync(indexSidecarPathForDb(dbPath));
+
+    const status = await collectStatus({
+      rootDir: root,
+      dbPath,
+      selector: { kind: "all", root },
+    });
+    const probe = getLastCoverageProbeStats();
+
+    expect(status.requestedCoverage?.freshness).toBe("fresh");
+    expect(probe?.dbOpens).toBe(1);
+  });
+
+  test("stale sidecar identity falls back to SQLite", async () => {
+    const { root, dbPath } = writeCodexFixture("sidecar-stale");
+    await syncSessions({ dbPath, selector: { kind: "all", root } });
+
+    const sidecarPath = indexSidecarPathForDb(dbPath);
+    const parsed = JSON.parse(readFileSync(sidecarPath, "utf8")) as { dbIdentity: { sqliteSize: number } };
+    parsed.dbIdentity.sqliteSize += 1;
+    writeFileSync(sidecarPath, `${JSON.stringify(parsed)}\n`);
+
+    const metadata = loadIndexMetadata(dbPath, "codex");
+    expect(metadata.opened).toBe(true);
+    expect(metadata.coverageRecords).toHaveLength(1);
+
+    const status = await collectStatus({
+      rootDir: root,
+      dbPath,
+      selector: { kind: "all", root },
+    });
+    expect(status.requestedCoverage?.freshness).toBe("fresh");
+    expect(getLastCoverageProbeStats()?.dbOpens).toBe(1);
+  });
+
+  test("corrupt sidecar falls back to SQLite", async () => {
+    const { root, dbPath } = writeCodexFixture("sidecar-corrupt");
+    await syncSessions({ dbPath, selector: { kind: "all", root } });
+    writeFileSync(indexSidecarPathForDb(dbPath), "{not-json");
+
+    const status = await collectStatus({
+      rootDir: root,
+      dbPath,
+      selector: { kind: "all", root },
+    });
+    expect(status.requestedCoverage?.freshness).toBe("fresh");
+    expect(getLastCoverageProbeStats()?.dbOpens).toBe(1);
+  });
+});
+
+function writeCodexFixture(name: string): { root: string; dbPath: string } {
+  const base = mkdtempSync(join(tmpdir(), `cxs-sidecar-${name}-`));
+  tempDirs.push(base);
+  const root = join(base, "sessions");
+  const day = join(root, "2026", "04", "22");
+  mkdirSync(day, { recursive: true });
+  writeFileSync(
+    join(day, "rollout-2026-04-22T10-00-00-11111111-1111-4111-8111-111111111111.jsonl"),
+    [
+      line("session_meta", { id: "11111111-1111-4111-8111-111111111111", cwd: `/tmp/${name}` }),
+      line("event_msg", { type: "user_message", message: `${name} user message` }),
+      line("event_msg", { type: "agent_message", message: `${name} agent reply` }),
+    ].join("\n"),
+  );
+  return { root, dbPath: join(base, "index.sqlite") };
+}
+
+function line(type: string, payload: Record<string, unknown>): string {
+  return JSON.stringify({
+    timestamp: new Date("2026-04-22T00:00:00.000Z").toISOString(),
+    type,
+    payload,
+  });
+}

--- a/src/index-sidecar.ts
+++ b/src/index-sidecar.ts
@@ -1,0 +1,396 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, parse, resolve } from "node:path";
+import { INDEX_VERSION } from "./env";
+import {
+  buildSourceFileMetaResolver,
+  getStatsCounts,
+  listCoverageRecords,
+  loadSourceFileMetaCache,
+  withReadDb,
+  type Db,
+} from "./db";
+import { tableExists } from "./db/sql";
+import type { SourceFileMetaCacheEntry } from "./db/file-meta-cache";
+import type {
+  CoverageRecord,
+  SessionSourceId,
+  SourceFileMetaResolver,
+  StatusSummary,
+} from "./types";
+import { SESSION_SOURCE_IDS } from "./types";
+
+export const INDEX_SIDECAR_VERSION = 1;
+export const INDEX_SIDECAR_FILE_SUFFIX = ".meta.json";
+
+export interface IndexSidecarDbIdentity {
+  sqliteMtimeMs: number;
+  sqliteSize: number;
+  walMtimeMs: number;
+  walSize: number;
+}
+
+export interface IndexSidecarFileMeta extends SourceFileMetaCacheEntry {
+  filePath: string;
+}
+
+export interface IndexSidecarSourceSlice {
+  sessionCount: number;
+  messageCount: number;
+  earliestStartedAt: string | null;
+  latestEndedAt: string | null;
+  lastSyncAt: string | null;
+  coverageRecords: CoverageRecord[];
+  fileMeta: IndexSidecarFileMeta[];
+}
+
+export interface IndexSidecar {
+  version: number;
+  indexVersion: string;
+  writtenAt: string;
+  dbIdentity: IndexSidecarDbIdentity;
+  sources: Partial<Record<SessionSourceId, IndexSidecarSourceSlice>>;
+}
+
+export interface IndexMetadata {
+  opened: boolean;
+  coverageRecords: CoverageRecord[];
+  metaResolver?: SourceFileMetaResolver;
+  index: StatusSummary["index"];
+}
+
+/**
+ * Sidecar lives next to the body index: `index.sqlite` → `index.meta.json`.
+ * Status/find coverage proofs read this file; they open SQLite only when the
+ * sidecar is missing or its db identity no longer matches.
+ */
+export function indexSidecarPathForDb(dbPath: string): string {
+  const resolved = resolve(dbPath);
+  const parsed = parse(resolved);
+  return resolve(parsed.dir, `${parsed.name}${INDEX_SIDECAR_FILE_SUFFIX}`);
+}
+
+export function readDbIdentity(dbPath: string): IndexSidecarDbIdentity {
+  return {
+    ...fileIdentity(dbPath, "sqlite" as const),
+    ...fileIdentity(`${dbPath}-wal`, "wal" as const),
+  };
+}
+
+export function dbIdentitiesMatch(left: IndexSidecarDbIdentity, right: IndexSidecarDbIdentity): boolean {
+  return left.sqliteMtimeMs === right.sqliteMtimeMs
+    && left.sqliteSize === right.sqliteSize
+    && left.walMtimeMs === right.walMtimeMs
+    && left.walSize === right.walSize;
+}
+
+export function loadIndexMetadata(dbPath: string, sourceId: SessionSourceId): IndexMetadata {
+  if (!existsSync(dbPath)) {
+    return {
+      opened: false,
+      coverageRecords: [],
+      index: emptyIndexStatus(),
+    };
+  }
+
+  const sidecar = readIndexSidecar(dbPath);
+  if (sidecar) {
+    const slice = sidecar.sources[sourceId];
+    return {
+      opened: false,
+      coverageRecords: slice?.coverageRecords ?? [],
+      metaResolver: buildSourceFileMetaResolver(fileMetaMap(slice?.fileMeta ?? [])),
+      index: indexStatusFromSlice(dbPath, slice),
+    };
+  }
+
+  return withReadDb(dbPath, (db) => ({
+    opened: true,
+    coverageRecords: listCoverageRecordsForStatus(db, sourceId),
+    metaResolver: buildSourceFileMetaResolver(loadSourceFileMetaCache(db, sourceId)),
+    index: readIndexStatus(db, dbPath, sourceId),
+  }));
+}
+
+/**
+ * Snapshot metadata from an already-open write connection. Caller must close
+ * the connection (and preferably checkpoint WAL) before `writeIndexSidecar`.
+ */
+export function snapshotIndexSidecar(db: Db): Omit<IndexSidecar, "writtenAt" | "dbIdentity"> {
+  const sources: IndexSidecar["sources"] = {};
+  for (const sourceId of SESSION_SOURCE_IDS) {
+    const counts = tableExists(db, "sessions")
+      ? tableColumnExists(db, "sessions", "source_id")
+        ? getStatsCounts(db, sourceId)
+        : sourceId === "codex"
+          ? getLegacyCodexStatsCounts(db)
+          : emptyIndexCounts()
+      : emptyIndexCounts();
+    sources[sourceId] = {
+      ...counts,
+      coverageRecords: listCoverageRecordsForStatus(db, sourceId),
+      fileMeta: serializeFileMeta(loadSourceFileMetaCache(db, sourceId)),
+    };
+  }
+  return {
+    version: INDEX_SIDECAR_VERSION,
+    indexVersion: INDEX_VERSION,
+    sources,
+  };
+}
+
+export function checkpointIndexWal(db: Db): void {
+  db.pragma("wal_checkpoint(TRUNCATE)");
+}
+
+export function writeIndexSidecar(
+  dbPath: string,
+  snapshot: Omit<IndexSidecar, "writtenAt" | "dbIdentity">,
+): void {
+  const sidecarPath = indexSidecarPathForDb(dbPath);
+  const payload: IndexSidecar = {
+    ...snapshot,
+    writtenAt: new Date().toISOString(),
+    dbIdentity: readDbIdentity(dbPath),
+  };
+  atomicWriteJson(sidecarPath, payload);
+}
+
+/**
+ * Dual-write helper for sync: snapshot while the write connection is open,
+ * checkpoint WAL, close, then atomically replace the sidecar. A sidecar
+ * failure must not fail a completed sync — the next status falls back to
+ * SQLite when identity does not match.
+ */
+export function persistIndexSidecarAfterWrite(db: Db, dbPath: string): void {
+  const snapshot = snapshotIndexSidecar(db);
+  try {
+    checkpointIndexWal(db);
+  } catch {
+    // Identity includes the WAL file, so a failed checkpoint is still safe.
+  }
+  db.close();
+  try {
+    writeIndexSidecar(dbPath, snapshot);
+  } catch {
+    // Projection only. Status/find reopen SQLite when the sidecar is absent
+    // or its db identity no longer matches.
+  }
+}
+
+export function readIndexSidecar(dbPath: string): IndexSidecar | null {
+  const sidecarPath = indexSidecarPathForDb(dbPath);
+  if (!existsSync(sidecarPath)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(sidecarPath, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isIndexSidecar(parsed)) return null;
+  if (!dbIdentitiesMatch(parsed.dbIdentity, readDbIdentity(dbPath))) return null;
+  return parsed;
+}
+
+function fileIdentity(path: string, kind: "sqlite"): Pick<IndexSidecarDbIdentity, "sqliteMtimeMs" | "sqliteSize">;
+function fileIdentity(path: string, kind: "wal"): Pick<IndexSidecarDbIdentity, "walMtimeMs" | "walSize">;
+function fileIdentity(
+  path: string,
+  kind: "sqlite" | "wal",
+): Pick<IndexSidecarDbIdentity, "sqliteMtimeMs" | "sqliteSize"> | Pick<IndexSidecarDbIdentity, "walMtimeMs" | "walSize"> {
+  const missing = !existsSync(path);
+  const stats = missing ? null : statSync(path);
+  const mtimeMs = stats ? Math.round(stats.mtimeMs) : 0;
+  const size = stats ? stats.size : 0;
+  return kind === "sqlite"
+    ? { sqliteMtimeMs: mtimeMs, sqliteSize: size }
+    : { walMtimeMs: mtimeMs, walSize: size };
+}
+
+function fileMetaMap(entries: IndexSidecarFileMeta[]): Map<string, SourceFileMetaCacheEntry> {
+  const cache = new Map<string, SourceFileMetaCacheEntry>();
+  for (const entry of entries) {
+    cache.set(entry.filePath, {
+      mtimeMs: entry.mtimeMs,
+      size: entry.size,
+      cwd: entry.cwd,
+      pathDate: entry.pathDate,
+      extraFingerprint: entry.extraFingerprint,
+    });
+  }
+  return cache;
+}
+
+function serializeFileMeta(cache: Map<string, SourceFileMetaCacheEntry>): IndexSidecarFileMeta[] {
+  return [...cache.entries()].map(([filePath, entry]) => ({ filePath, ...entry }));
+}
+
+function indexStatusFromSlice(dbPath: string, slice: IndexSidecarSourceSlice | undefined): StatusSummary["index"] {
+  return {
+    exists: true,
+    sessionCount: slice?.sessionCount ?? 0,
+    messageCount: slice?.messageCount ?? 0,
+    earliestStartedAt: slice?.earliestStartedAt ?? null,
+    latestEndedAt: slice?.latestEndedAt ?? null,
+    dbSizeBytes: dbFileSize(dbPath),
+    lastSyncAt: slice?.lastSyncAt ?? null,
+  };
+}
+
+function emptyIndexStatus(): StatusSummary["index"] {
+  return {
+    exists: false,
+    sessionCount: 0,
+    messageCount: 0,
+    earliestStartedAt: null,
+    latestEndedAt: null,
+    dbSizeBytes: 0,
+    lastSyncAt: null,
+  };
+}
+
+function emptyIndexCounts(): ReturnType<typeof getStatsCounts> {
+  return {
+    sessionCount: 0,
+    messageCount: 0,
+    earliestStartedAt: null,
+    latestEndedAt: null,
+    lastSyncAt: null,
+  };
+}
+
+function readIndexStatus(db: Db, dbPath: string, sourceId: SessionSourceId): StatusSummary["index"] {
+  const counts = !tableExists(db, "sessions")
+    ? emptyIndexCounts()
+    : !tableColumnExists(db, "sessions", "source_id")
+      ? sourceId === "codex"
+        ? getLegacyCodexStatsCounts(db)
+        : emptyIndexCounts()
+      : getStatsCounts(db, sourceId);
+  return {
+    exists: true,
+    sessionCount: counts.sessionCount,
+    messageCount: counts.messageCount,
+    earliestStartedAt: counts.earliestStartedAt,
+    latestEndedAt: counts.latestEndedAt,
+    dbSizeBytes: dbFileSize(dbPath),
+    lastSyncAt: counts.lastSyncAt,
+  };
+}
+
+function listCoverageRecordsForStatus(db: Db, sourceId: SessionSourceId): CoverageRecord[] {
+  if (!tableColumnExists(db, "coverage", "source_id")) return [];
+  return listCoverageRecords(db, sourceId);
+}
+
+function getLegacyCodexStatsCounts(db: Db): ReturnType<typeof getStatsCounts> {
+  return db
+    .prepare(`
+      SELECT
+        COUNT(*) AS sessionCount,
+        COALESCE(SUM(message_count), 0) AS messageCount,
+        MIN(started_at) AS earliestStartedAt,
+        MAX(ended_at) AS latestEndedAt,
+        MAX(updated_at) AS lastSyncAt
+      FROM sessions
+    `)
+    .get() as ReturnType<typeof getStatsCounts>;
+}
+
+function tableColumnExists(db: Db, tableName: string, columnName: string): boolean {
+  return db
+    .prepare<[string, string], { name: string }>(`
+      SELECT name
+      FROM pragma_table_info(?)
+      WHERE name = ?
+      LIMIT 1
+    `)
+    .get(tableName, columnName) !== undefined;
+}
+
+function dbFileSize(dbPath: string): number {
+  try {
+    return statSync(dbPath).size;
+  } catch {
+    return 0;
+  }
+}
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(value)}\n`, "utf8");
+  try {
+    renameSync(tempPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Keep the original write error.
+    }
+    throw error;
+  }
+}
+
+function isIndexSidecar(value: unknown): value is IndexSidecar {
+  if (!isRecord(value)) return false;
+  if (value.version !== INDEX_SIDECAR_VERSION) return false;
+  if (typeof value.indexVersion !== "string") return false;
+  if (typeof value.writtenAt !== "string") return false;
+  if (!isDbIdentity(value.dbIdentity)) return false;
+  if (!isRecord(value.sources)) return false;
+  for (const [sourceId, slice] of Object.entries(value.sources)) {
+    if (!SESSION_SOURCE_IDS.includes(sourceId as SessionSourceId)) return false;
+    if (slice !== undefined && !isSourceSlice(slice)) return false;
+  }
+  return true;
+}
+
+function isDbIdentity(value: unknown): value is IndexSidecarDbIdentity {
+  if (!isRecord(value)) return false;
+  return Number.isFinite(value.sqliteMtimeMs)
+    && Number.isFinite(value.sqliteSize)
+    && Number.isFinite(value.walMtimeMs)
+    && Number.isFinite(value.walSize);
+}
+
+function isSourceSlice(value: unknown): value is IndexSidecarSourceSlice {
+  if (!isRecord(value)) return false;
+  if (!Number.isFinite(value.sessionCount) || !Number.isFinite(value.messageCount)) return false;
+  if (!isNullString(value.earliestStartedAt) || !isNullString(value.latestEndedAt) || !isNullString(value.lastSyncAt)) {
+    return false;
+  }
+  if (!Array.isArray(value.coverageRecords) || !value.coverageRecords.every(isCoverageRecord)) return false;
+  if (!Array.isArray(value.fileMeta) || !value.fileMeta.every(isFileMeta)) return false;
+  return true;
+}
+
+function isCoverageRecord(value: unknown): value is CoverageRecord {
+  if (!isRecord(value)) return false;
+  return Number.isFinite(value.id)
+    && isRecord(value.selector)
+    && typeof value.sourceFingerprint === "string"
+    && typeof value.sourceFileSetFingerprint === "string"
+    && Number.isFinite(value.sourceFileCount)
+    && Number.isFinite(value.indexedSessionCount)
+    && typeof value.completedAt === "string"
+    && typeof value.indexVersion === "string";
+}
+
+function isFileMeta(value: unknown): value is IndexSidecarFileMeta {
+  if (!isRecord(value)) return false;
+  return typeof value.filePath === "string"
+    && Number.isFinite(value.mtimeMs)
+    && Number.isFinite(value.size)
+    && typeof value.cwd === "string"
+    && (value.pathDate === null || typeof value.pathDate === "string")
+    && typeof value.extraFingerprint === "string";
+}
+
+function isNullString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -19,6 +19,7 @@ import {
   replaceSession,
   upsertSourceFileMetaCache,
 } from "./db";
+import { persistIndexSidecarAfterWrite } from "./index-sidecar";
 import { canonicalizeSelector, selectorSource } from "./selector";
 import { getSessionSourceAdapter } from "./sources";
 import { SourceInventoryError } from "./source-inventory";
@@ -185,9 +186,13 @@ export async function syncSessions(options: SyncOptions = {}): Promise<SyncSumma
         // to full content scans when rows are missing.
       }
 
+      // Metadata plane for status/find coverage proofs. Written after the
+      // SQLite commit so a crash mid-sync never leaves a newer sidecar than
+      // the body index. persistIndexSidecarAfterWrite closes `db`.
+      persistIndexSidecarAfterWrite(db, dbPath);
       return summary;
     } finally {
-      db.close();
+      if (db.open) db.close();
     }
   });
 }

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -158,6 +158,8 @@ describe("collectStatus", () => {
     expect(snapshotSpy).toHaveBeenCalledTimes(1);
     expect(snapshotSpy.mock.calls[0]?.[0]).toMatchObject({ kind: "all", root: tempDir });
     expect(probe?.snapshotCalls).toBe(1);
+    // Direct replaceCoverage does not write the sidecar, so status falls back
+    // to one SQLite open. After sync, the sidecar path is dbOpens=0.
     expect(probe?.dbOpens).toBe(1);
   });
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,14 +1,5 @@
-import { existsSync, statSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { INDEX_VERSION, DEFAULT_DB_PATH } from "./env";
-import {
-  buildSourceFileMetaResolver,
-  getStatsCounts,
-  listCoverageRecords,
-  loadSourceFileMetaCache,
-  withReadDb,
-  type Db,
-} from "./db";
 import {
   createCachedSnapshotter,
   emptyCoverageProbeStats,
@@ -17,12 +8,12 @@ import {
   proveRequestedCoverage,
   type CoverageProbeStats,
 } from "./coverage-freshness";
+import { loadIndexMetadata } from "./index-sidecar";
 import { selectorSource } from "./selector";
 import { getSessionSourceAdapter } from "./sources";
 import type { SessionSourceAdapter } from "./sources/types";
 import type {
   CoverageInventoryStatus,
-  CoverageRecord,
   Selector,
   SessionSourceId,
   SourceFileMeta,
@@ -45,7 +36,7 @@ export async function collectStatus(options: {
   const dbPath = options.dbPath ?? DEFAULT_DB_PATH;
   const stats = emptyCoverageProbeStats();
   const dbStarted = performance.now();
-  const dbState = loadStatusDbState(dbPath, source.id);
+  const dbState = loadIndexMetadata(dbPath, source.id);
   stats.dbMs = performance.now() - dbStarted;
   stats.dbOpens = dbState.opened ? 1 : 0;
 
@@ -106,34 +97,10 @@ export async function collectStatus(options: {
   return summary;
 }
 
-interface StatusDbState {
-  opened: boolean;
-  coverageRecords: CoverageRecord[];
-  metaResolver?: SourceFileMetaResolver;
-  index: StatusSummary["index"];
-}
-
 interface StatusSourceContext {
   source: SessionSourceAdapter;
   files: SourceFileMeta[];
   inventory: SourceInventory;
-}
-
-function loadStatusDbState(dbPath: string, sourceId: SessionSourceId): StatusDbState {
-  if (!existsSync(dbPath)) {
-    return {
-      opened: false,
-      coverageRecords: [],
-      index: emptyIndexStatus(),
-    };
-  }
-
-  return withReadDb(dbPath, (db) => ({
-    opened: true,
-    coverageRecords: listCoverageRecordsForStatus(db, sourceId),
-    metaResolver: buildSourceFileMetaResolver(loadSourceFileMetaCache(db, sourceId)),
-    index: readIndexStatus(db, dbPath),
-  }));
 }
 
 function statusSourceCacheKey(sourceId: SessionSourceId, root: string): string {
@@ -174,87 +141,4 @@ function compactSourceInventory(inventory: SourceInventory): SourceInventory {
     pathDateRange: inventory.pathDateRange,
     cwdGroups: [],
   };
-}
-
-function emptyIndexStatus(): StatusSummary["index"] {
-  return {
-    exists: false,
-    sessionCount: 0,
-    messageCount: 0,
-    earliestStartedAt: null,
-    latestEndedAt: null,
-    dbSizeBytes: 0,
-    lastSyncAt: null,
-  };
-}
-
-function readIndexStatus(db: Db, dbPath: string): StatusSummary["index"] {
-  const counts = !tableExists(db, "sessions")
-    ? emptyIndexCounts()
-    : !tableColumnExists(db, "sessions", "source_id")
-      ? getLegacyCodexStatsCounts(db)
-      : getStatsCounts(db);
-  let dbSizeBytes = 0;
-  try {
-    dbSizeBytes = statSync(dbPath).size;
-  } catch {
-    dbSizeBytes = 0;
-  }
-
-  return {
-    exists: true,
-    sessionCount: counts.sessionCount,
-    messageCount: counts.messageCount,
-    earliestStartedAt: counts.earliestStartedAt,
-    latestEndedAt: counts.latestEndedAt,
-    dbSizeBytes,
-    lastSyncAt: counts.lastSyncAt,
-  };
-}
-
-function listCoverageRecordsForStatus(db: Db, sourceId: SessionSourceId): CoverageRecord[] {
-  if (!tableColumnExists(db, "coverage", "source_id")) return [];
-  return listCoverageRecords(db, sourceId);
-}
-
-function emptyIndexCounts(): ReturnType<typeof getStatsCounts> {
-  return {
-    sessionCount: 0,
-    messageCount: 0,
-    earliestStartedAt: null,
-    latestEndedAt: null,
-    lastSyncAt: null,
-  };
-}
-
-function getLegacyCodexStatsCounts(db: Db): ReturnType<typeof getStatsCounts> {
-  const row = db
-    .prepare(`
-      SELECT
-        COUNT(*) AS sessionCount,
-        COALESCE(SUM(message_count), 0) AS messageCount,
-        MIN(started_at) AS earliestStartedAt,
-        MAX(ended_at) AS latestEndedAt,
-        MAX(updated_at) AS lastSyncAt
-      FROM sessions
-    `)
-    .get() as ReturnType<typeof getStatsCounts>;
-  return row;
-}
-
-function tableColumnExists(db: Db, tableName: string, columnName: string): boolean {
-  return db
-    .prepare<[string, string], { name: string }>(`
-      SELECT name
-      FROM pragma_table_info(?)
-      WHERE name = ?
-      LIMIT 1
-    `)
-    .get(tableName, columnName) !== undefined;
-}
-
-function tableExists(db: Db, tableName: string): boolean {
-  return db
-    .prepare<[string], unknown>("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
-    .get(tableName) !== undefined;
 }


### PR DESCRIPTION
## Summary
- Sync now writes `index.meta.json` beside `index.sqlite` after the SQLite commit: coverage records, per-source counts, and the source-file meta cache.
- `status --selector` and `find` coverage proofs read that sidecar when its sqlite+wal identity still matches. They open the body database only when the sidecar is missing, corrupt, or stale.
- Freshness semantics stay byte-identical to the sync-time fingerprints. Sync remains the only writer. Tests cover sidecar hit (`dbOpens=0`), missing/stale/corrupt fallback, and the existing replaceCoverage path that still opens SQLite once.

## Test plan
- [x] `npm run check` (252 tests)
- [x] Live Codex corpus: sidecar 277KB beside 375MB DB; `status --source codex --selector '{"kind":"all"}' --json` is `dbOpens=0`, ~60ms warm vs ~40ms `--version` floor
- [ ] CI green
- [ ] After merge: bump 0.4.2, tag, wait for npm, update PATH CLI + skill + changelog site


Made with [Cursor](https://cursor.com)