### PR TITLE
perf(cli): load better-sqlite3 only when a database is opened

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - session-level FTS 使用显式字段权重：title 8.0、compact 4.0、summary 3.0、reasoning summary 1.2
 - `classifyQueryProfile()` 仍存在，但当前评分没有按 `broad/exact` 做显式分权
 - parser 只把 `event_msg` 里的 user / assistant 写入 `messages`；`type=compacted` 与 `response_item.reasoning.summary` 只进入 session-level 索引字段，不形成可回读 message projection
+- `better-sqlite3` 只在第一次 `openReadDb` / `openWriteDb` 时才 `dlopen`；sidecar 命中的 `status` / `--version` 不加载 native addon。没有默认 daemon / watcher
 
 不要把下面这些说成已完成：
 
@@ -42,6 +43,7 @@
 - [db.ts](src/db.ts): SQLite facade；具体 schema / store / coverage 模块在 `src/db/`
 - [query.ts](src/query.ts): 查询 facade；find / read / list / stats / search / snippet 模块在 `src/query/`
 - [status.ts](src/status.ts): status 输出编排
+- [index-sidecar.ts](src/index-sidecar.ts): metadata sidecar 只读/只写 JSON；SQLite 回退与 sync persist 在 [index-sidecar-sqlite.ts](src/index-sidecar-sqlite.ts)
 - [selector.ts](src/selector.ts): selector 解析与覆盖蕴含规则
 - [source-inventory.ts](src/source-inventory.ts): raw sessions metadata inventory
 - [types.ts](src/types.ts): CLI JSON contract 与核心类型

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Codex adapter 会把原有 `sessionUuid` 映射为 source-aware identity：
 
 ### 1. 同步
 
-[status.ts](../src/status.ts) 返回执行上下文、compact source inventory、index 状态，以及 `--selector`/`--cwd` 时的 `requestedCoverage` 证明。默认不 dump 历史 `coverage[]` 或 `cwdGroups`（`--inventory` 才做逐行审计）。它可以扫描 raw sessions 的 metadata，但不回答内容问题。coverage / index counts / file-meta cache 来自 sync 写在 `index.sqlite` 旁的 `index.meta.json` sidecar；sidecar 的 db identity（sqlite+wal mtime/size）与当前文件一致时，`status` 不打开正文库。sidecar 缺失或 identity 不匹配时回退一次只读 SQLite。探测只对 covering selector 做 snapshot，不重放历史 cwd/date_range 行。
+[status.ts](../src/status.ts) 返回执行上下文、compact source inventory、index 状态，以及 `--selector`/`--cwd` 时的 `requestedCoverage` 证明。默认不 dump 历史 `coverage[]` 或 `cwdGroups`（`--inventory` 才做逐行审计）。它可以扫描 raw sessions 的 metadata，但不回答内容问题。coverage / index counts / file-meta cache 来自 sync 写在 `index.sqlite` 旁的 `index.meta.json` sidecar；sidecar 的 db identity（sqlite mtime/size + WAL size；空 WAL 与缺失 WAL 等价）与当前文件一致时，`status` 不打开正文库、不加载 `better-sqlite3`。sidecar 缺失或 identity 不匹配时回退一次只读 SQLite。探测只对 covering selector 做 snapshot，不重放历史 cwd/date_range 行。
 
 [indexer.ts](../src/indexer.ts) 按显式 selector 扫描选定 source 的 session snapshot。当前公开 source 可以是 Codex、Claude Code 或 Pi；增量判断仍基于文件 `mtime`、`size` 和 `indexVersion`。
 
@@ -84,7 +84,7 @@ SQLite 访问层当前已经按 reader / writer 分流：
 
 - `sync` 走 writer 连接，负责 schema ensure、WAL 初始化、写入事务，并在同一把 sync lock 内把 coverage / counts / file-meta 投影到 `index.meta.json`
 - `find` / `read-range` / `read-page` / `list` / `stats` 走只读连接；`find` 的 coverage 证明优先读 sidecar，FTS 仍读 SQLite
-- `status` 不写 index；它读 raw metadata 和 sidecar，只在 sidecar 不可用时打开只读 SQLite
+- `status` 不写 index；它读 raw metadata 和 sidecar，只在 sidecar 不可用时打开只读 SQLite。sidecar 命中时进程不加载 `better-sqlite3` native addon（`--version` 与 sidecar-hit `status` 同路径）
 - 读路径默认设置 `busy_timeout`，避免并发 agent 多查时把瞬时锁竞争直接暴露成 `SQLITE_BUSY`
 - `sync` 额外有文件级 single-writer lock；遇到活跃 writer 会等待，遇到 dead pid 残留锁会自动清理
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -95,7 +95,7 @@ By default, source-scoped commands read Codex sessions from `~/.codex/sessions`.
 ~/.local/state/shlog/index.meta.json
 ```
 
-`index.sqlite` is the retrieval source of truth. `index.meta.json` is a sync-written metadata sidecar (coverage fingerprints, session/message counts, source file meta cache). `status` and `find` coverage proofs read the sidecar when its sqlite+wal identity still matches; they open the body database only when the sidecar is missing or stale. Sync remains the only writer.
+`index.sqlite` is the retrieval source of truth. `index.meta.json` is a sync-written metadata sidecar (coverage fingerprints, session/message counts, source file meta cache). `status` and `find` coverage proofs read the sidecar when its sqlite+wal identity still matches; they open the body database only when the sidecar is missing or stale. A sidecar hit does not load the `better-sqlite3` native addon. Sync remains the only writer. There is no default daemon or watcher.
 
 `$XDG_STATE_HOME` is respected, and `SHLOG_DATA_DIR` has the highest priority. `CXS_DATA_DIR` still works as a legacy alias:
 

--- a/skill-packages/sherlog/SKILL.md
+++ b/skill-packages/sherlog/SKILL.md
@@ -18,7 +18,7 @@ description: "Use proactively for local agent-session history and prior setup ar
 | metadata projection：最早/最新、数量、分布、cwd/session 清单、大 session | 只读 SQLite 查询 index 的 `sessions` 表；必要时 `list` | metadata 候选完整；涉及内容时已再用 `read-*` 验证 |
 | semantic recall：主题、关键词、历史配置考古 | `find <query> --json`；按需加 `--cwd/--root/--selector` | 已执行结果的 `evidenceRead.argv`，不只看 title/snippet |
 | context reading：已知 `sessionRef` / seq | `read-range` 或 `read-page` | 已读足够上下文回答问题 |
-| coverage / freshness / index availability | `status --selector/--cwd --json` | 已按 `requestedCoverage.recommendedAction` 决定 query 或同范围 sync。默认不要读 `coverage[]` / `cwdGroups`；审计才用 `--inventory`。status 读 sidecar，不打开正文库 |
+| coverage / freshness / index availability | `status --selector/--cwd --json` | 已按 `requestedCoverage.recommendedAction` 决定 query 或同范围 sync。默认不要读 `coverage[]` / `cwdGroups`；审计才用 `--inventory`。status 读 sidecar，不打开正文库，也不加载 SQLite native addon |
 | mutation：建索引或更新 coverage | bare `sync`（first-install Codex bootstrap）或 scoped `sync` | sync 无未解决 error；cold 迁移已注册 cold root |
 
 ## Canonical policy

--- a/skill-packages/sherlog/references/cli-surface.md
+++ b/skill-packages/sherlog/references/cli-surface.md
@@ -16,7 +16,7 @@
 
 ## status
 
-Purpose：执行上下文、compact source inventory、index 与 coverage proof。不回答内容，不写状态。默认 JSON 是小证明（`requestedCoverage` + compact index/inventory），不是历史 `coverage[]` / `cwdGroups` 审计。coverage 证明读 sync 写的 `index.meta.json` sidecar，不打开正文库；sidecar 缺失或与 sqlite identity 不一致时才回退只读 SQLite。
+Purpose：执行上下文、compact source inventory、index 与 coverage proof。不回答内容，不写状态。默认 JSON 是小证明（`requestedCoverage` + compact index/inventory），不是历史 `coverage[]` / `cwdGroups` 审计。coverage 证明读 sync 写的 `index.meta.json` sidecar，不打开正文库、不加载 `better-sqlite3`；sidecar 缺失或与 sqlite identity 不一致时才回退只读 SQLite。
 
 ```bash
 "${SHLOG_BIN:-${CXS_BIN:-shlog}}" status --json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ import {
 import {
   IndexSchemaUpgradeRequiredError,
   IndexUnavailableError,
-} from "./db";
+} from "./db/errors";
 import { loadIndexMetadata } from "./index-sidecar";
 import {
   createCachedSnapshotter,
@@ -33,26 +33,8 @@ import { getSessionSourceAdapter, listSessionSourceAdapters } from "./sources";
 // Runs before any subcommand so `shlog stats` etc. see the migrated db, not
 // just `shlog sync`. Idempotent + silent on failure (worst case is a re-sync).
 migrateLegacyDataDirIfNeeded();
-import {
-  printFindResults,
-  printReadPage,
-  printReadRangeResult,
-  printSessionList,
-  printStats,
-  printStatus,
-  printSyncSummary,
-} from "./format";
-import { SyncError, syncSessions } from "./indexer";
-import {
-  buildZeroResultRefinement,
-  collectStats,
-  findSessions,
-  getMessagePage,
-  getMessageRange,
-  listSessionSummaries,
-  SessionNotFoundError,
-} from "./query";
 import { DEFAULT_MAX_MESSAGE_CHARS } from "./query/message-elision";
+import { SessionNotFoundError } from "./query/session-not-found";
 import { canonicalizeSelector, parseSelectorJson, SelectorParseError, selectorSource } from "./selector";
 import { collectStatus } from "./status";
 import { SyncLockTimeoutError } from "./sync-lock";
@@ -102,6 +84,7 @@ program
         console.log(JSON.stringify(status, null, 2));
         return;
       }
+      const { printStatus } = await import("./format");
       printStatus(status);
     } catch (error) {
       if (error instanceof SourceOptionError) {
@@ -137,6 +120,7 @@ program
   )
   .option("--json", "输出 JSON")
   .action(async (options) => {
+    const { SyncError, syncSessions } = await import("./indexer");
     try {
       const sourceId = publicSource(options.source);
       const selector = syncSelector({ ...options, source: sourceId });
@@ -152,12 +136,14 @@ program
         console.log(JSON.stringify(summary, null, 2));
         return;
       }
+      const { printSyncSummary } = await import("./format");
       printSyncSummary(summary);
     } catch (error) {
       if (error instanceof SyncError) {
         if (options.json) {
           console.error(JSON.stringify(error.summary, null, 2));
         } else {
+          const { printSyncSummary } = await import("./format");
           printSyncSummary(error.summary);
         }
         process.exitCode = 1;
@@ -282,6 +268,7 @@ program
   .option("--json", "输出 JSON")
   .action(async (query, options) => {
     await runReadCommand(Boolean(options.json), async () => {
+      const { findSessions } = await import("./query");
       const limit = parsePositiveInt(options.limit, 10);
       const sort = normalizeFindSort(options.sort);
       const sourceIds = publicFindSources(options.source, options.selector);
@@ -309,7 +296,7 @@ program
       }));
       const merged = mergeFindSummaries(query, sort, options.excludeSession ?? [], summaries, limit);
       const result = merged.results.length === 0
-        ? { ...merged, zeroResults: buildZeroResultsDiagnosis(query, merged.coverage) }
+        ? { ...merged, zeroResults: await buildZeroResultsDiagnosis(query, merged.coverage) }
         : merged;
       // performance.now() 自 timeOrigin(进程启动)起算 ≈ 本次端到端耗时,
       // 含 better-sqlite3 模块加载;shlog 是一次性进程,所以这就是诚实的端到端。
@@ -325,6 +312,7 @@ program
         }, null, 2));
         return;
       }
+      const { printFindResults } = await import("./format");
       printFindResults(result.query, result.results, result.scannedMessageCount, elapsedMs, statsReadoutEnabled(), result.nextAction);
     });
   });
@@ -341,7 +329,8 @@ program
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--json", "输出 JSON")
   .action((sessionRef, options) => {
-    runReadCommand(Boolean(options.json), () => {
+    runReadCommand(Boolean(options.json), async () => {
+      const { getMessageRange } = await import("./query");
       const sourceId = publicReadSource(options.source, sessionRef);
       const result = getMessageRange(options.db, sessionRefForSource(sessionRef, sourceId), {
         seq: optionalInt(options.seq),
@@ -355,6 +344,7 @@ program
         console.log(JSON.stringify({ ...result, elapsedMs }, null, 2));
         return;
       }
+      const { printReadRangeResult } = await import("./format");
       printReadRangeResult(
         result.session,
         result.anchorSeq,
@@ -380,7 +370,8 @@ program
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--json", "输出 JSON")
   .action((sessionRef, options) => {
-    runReadCommand(Boolean(options.json), () => {
+    runReadCommand(Boolean(options.json), async () => {
+      const { getMessagePage } = await import("./query");
       const sourceId = publicReadSource(options.source, sessionRef);
       const result = getMessagePage(
         options.db,
@@ -394,6 +385,7 @@ program
         console.log(JSON.stringify({ ...result, elapsedMs }, null, 2));
         return;
       }
+      const { printReadPage } = await import("./format");
       printReadPage(
         result.session,
         result.offset,
@@ -423,7 +415,8 @@ program
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--json", "输出 JSON")
   .action((options) => {
-    runReadCommand(Boolean(options.json), () => {
+    runReadCommand(Boolean(options.json), async () => {
+      const { listSessionSummaries } = await import("./query");
       const sourceId = publicSource(options.source);
       const sort = normalizeListSort(options.sort);
       const selector = optionalSelector({ selector: options.selector, root: options.root, source: sourceId, rootOnlySelector: true });
@@ -439,6 +432,7 @@ program
         console.log(JSON.stringify(result, null, 2));
         return;
       }
+      const { printSessionList } = await import("./format");
       printSessionList(result.results, result.nextAction);
     });
   });
@@ -450,13 +444,15 @@ program
   .option("--db <path>", "覆盖默认数据库路径", DEFAULT_DB_PATH)
   .option("--json", "输出 JSON")
   .action((options) => {
-    runReadCommand(Boolean(options.json), () => {
+    runReadCommand(Boolean(options.json), async () => {
+      const { collectStats } = await import("./query");
       const sourceId = publicSource(options.source);
       const summary = collectStats(options.db, sourceId);
       if (options.json) {
         console.log(JSON.stringify(summary, null, 2));
         return;
       }
+      const { printStats } = await import("./format");
       printStats(summary);
     });
   });
@@ -710,7 +706,8 @@ function buildCrossSourceZeroResultsNextAction(): QueryNextAction {
  * offers deterministic broadening probes for over-constrained queries.
  * Informational only — read-only commands never sync implicitly.
  */
-function buildZeroResultsDiagnosis(query: string, coverage: CoverageStatus): ZeroResultsDiagnosis {
+async function buildZeroResultsDiagnosis(query: string, coverage: CoverageStatus): Promise<ZeroResultsDiagnosis> {
+  const { buildZeroResultRefinement } = await import("./query");
   const refinement = buildZeroResultRefinement(query);
   const reason: ZeroResultsDiagnosis["reason"] = coverage.freshness === "fresh"
     ? "fresh_miss"
@@ -745,7 +742,7 @@ async function assessFindCoverage(
   const dbStarted = performance.now();
   // Coverage proof reads the sync-written sidecar when its db identity
   // still matches. find still opens SQLite for FTS; this probe does not.
-  const metadata = loadIndexMetadata(dbPath, sourceId);
+  const metadata = await loadIndexMetadata(dbPath, sourceId);
   const { coverageRecords, metaResolver } = metadata;
   stats.dbOpens = metadata.opened ? 1 : 0;
   stats.dbMs = performance.now() - dbStarted;

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,8 +2,11 @@ export type { Db, SqlParams } from "./db/shared";
 export {
   IndexSchemaUpgradeRequiredError,
   IndexUnavailableError,
+} from "./db/errors";
+export {
   openReadDb,
   openWriteDb,
+  sqliteNativeModuleLoaded,
   withReadDb,
   withSourceAwareReadDb,
 } from "./db/connection";

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,23 +1,27 @@
 import { existsSync } from "node:fs";
-import Database from "better-sqlite3";
+import { createRequire } from "node:module";
+import type BetterSqlite3 from "better-sqlite3";
+import { IndexSchemaUpgradeRequiredError, IndexUnavailableError } from "./errors";
 import { ensureSchema } from "./schema";
 import { BUSY_TIMEOUT_MS, type Db } from "./shared";
 
-export class IndexUnavailableError extends Error {
-  constructor(public readonly dbPath: string) {
-    super(`index not found: ${dbPath}`);
-    this.name = "IndexUnavailableError";
+export { IndexSchemaUpgradeRequiredError, IndexUnavailableError } from "./errors";
+
+const require = createRequire(import.meta.url);
+
+type SqliteDatabaseConstructor = typeof BetterSqlite3;
+let sqliteDatabase: SqliteDatabaseConstructor | undefined;
+
+function loadSqlite(): SqliteDatabaseConstructor {
+  if (!sqliteDatabase) {
+    sqliteDatabase = require("better-sqlite3") as SqliteDatabaseConstructor;
   }
+  return sqliteDatabase;
 }
 
-export class IndexSchemaUpgradeRequiredError extends Error {
-  constructor(
-    public readonly dbPath: string,
-    public readonly missingColumns: string[],
-  ) {
-    super(`index schema is too old for source-aware read commands: ${dbPath}`);
-    this.name = "IndexSchemaUpgradeRequiredError";
-  }
+/** True only after a read/write connection has actually loaded the native addon. */
+export function sqliteNativeModuleLoaded(): boolean {
+  return sqliteDatabase !== undefined;
 }
 
 export function openReadDb(dbPath: string): Db {
@@ -25,6 +29,7 @@ export function openReadDb(dbPath: string): Db {
     throw new IndexUnavailableError(dbPath);
   }
 
+  const Database = loadSqlite();
   const db = new Database(dbPath, { readonly: true });
   db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
   db.pragma("query_only = ON");
@@ -55,6 +60,7 @@ export function withSourceAwareReadDb<T>(dbPath: string, fn: (db: Db) => T): T {
 }
 
 export function openWriteDb(dbPath: string): Db {
+  const Database = loadSqlite();
   const db = new Database(dbPath);
   db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
   db.pragma("journal_mode = WAL");

--- a/src/db/errors.ts
+++ b/src/db/errors.ts
@@ -1,0 +1,16 @@
+export class IndexUnavailableError extends Error {
+  constructor(public readonly dbPath: string) {
+    super(`index not found: ${dbPath}`);
+    this.name = "IndexUnavailableError";
+  }
+}
+
+export class IndexSchemaUpgradeRequiredError extends Error {
+  constructor(
+    public readonly dbPath: string,
+    public readonly missingColumns: string[],
+  ) {
+    super(`index schema is too old for source-aware read commands: ${dbPath}`);
+    this.name = "IndexSchemaUpgradeRequiredError";
+  }
+}

--- a/src/db/shared.ts
+++ b/src/db/shared.ts
@@ -1,6 +1,6 @@
-import Database from "better-sqlite3";
+import type BetterSqlite3 from "better-sqlite3";
 
-export type Db = Database.Database;
+export type Db = BetterSqlite3.Database;
 export type SqlParams = unknown[];
 
 export const BUSY_TIMEOUT_MS = 5000;

--- a/src/index-sidecar-sqlite.ts
+++ b/src/index-sidecar-sqlite.ts
@@ -1,0 +1,146 @@
+import { INDEX_VERSION } from "./env";
+import {
+  getStatsCounts,
+  listCoverageRecords,
+  loadSourceFileMetaCache,
+  withReadDb,
+  type Db,
+} from "./db";
+import { tableExists } from "./db/sql";
+import { buildSourceFileMetaResolver } from "./db/file-meta-cache";
+import type { SourceFileMetaCacheEntry } from "./db/file-meta-cache";
+import {
+  INDEX_SIDECAR_VERSION,
+  dbFileSize,
+  writeIndexSidecar,
+  type IndexMetadata,
+  type IndexSidecar,
+  type IndexSidecarFileMeta,
+} from "./index-sidecar";
+import type { CoverageRecord, SessionSourceId } from "./types";
+import { SESSION_SOURCE_IDS } from "./types";
+
+/**
+ * Snapshot metadata from an already-open write connection. Caller must close
+ * the connection (and preferably checkpoint WAL) before `writeIndexSidecar`.
+ */
+export function snapshotIndexSidecar(db: Db): Omit<IndexSidecar, "writtenAt" | "dbIdentity"> {
+  const sources: IndexSidecar["sources"] = {};
+  for (const sourceId of SESSION_SOURCE_IDS) {
+    const counts = tableExists(db, "sessions")
+      ? tableColumnExists(db, "sessions", "source_id")
+        ? getStatsCounts(db, sourceId)
+        : sourceId === "codex"
+          ? getLegacyCodexStatsCounts(db)
+          : emptyIndexCounts()
+      : emptyIndexCounts();
+    sources[sourceId] = {
+      ...counts,
+      coverageRecords: listCoverageRecordsForStatus(db, sourceId),
+      fileMeta: serializeFileMeta(loadSourceFileMetaCache(db, sourceId)),
+    };
+  }
+  return {
+    version: INDEX_SIDECAR_VERSION,
+    indexVersion: INDEX_VERSION,
+    sources,
+  };
+}
+
+export function checkpointIndexWal(db: Db): void {
+  db.pragma("wal_checkpoint(TRUNCATE)");
+}
+
+/**
+ * Dual-write helper for sync: snapshot while the write connection is open,
+ * checkpoint WAL, close, then atomically replace the sidecar. A sidecar
+ * failure must not fail a completed sync — the next status falls back to
+ * SQLite when identity does not match.
+ */
+export function persistIndexSidecarAfterWrite(db: Db, dbPath: string): void {
+  const snapshot = snapshotIndexSidecar(db);
+  try {
+    checkpointIndexWal(db);
+  } catch {
+    // Identity includes the WAL file, so a failed checkpoint is still safe.
+  }
+  db.close();
+  try {
+    writeIndexSidecar(dbPath, snapshot);
+  } catch {
+    // Projection only. Status/find reopen SQLite when the sidecar is absent
+    // or its db identity no longer matches.
+  }
+}
+
+export function loadIndexMetadataFromSqlite(dbPath: string, sourceId: SessionSourceId): IndexMetadata {
+  return withReadDb(dbPath, (db) => ({
+    opened: true,
+    coverageRecords: listCoverageRecordsForStatus(db, sourceId),
+    metaResolver: buildSourceFileMetaResolver(loadSourceFileMetaCache(db, sourceId)),
+    index: readIndexStatus(db, dbPath, sourceId),
+  }));
+}
+
+function serializeFileMeta(cache: Map<string, SourceFileMetaCacheEntry>): IndexSidecarFileMeta[] {
+  return [...cache.entries()].map(([filePath, entry]) => ({ filePath, ...entry }));
+}
+
+function emptyIndexCounts(): ReturnType<typeof getStatsCounts> {
+  return {
+    sessionCount: 0,
+    messageCount: 0,
+    earliestStartedAt: null,
+    latestEndedAt: null,
+    lastSyncAt: null,
+  };
+}
+
+function readIndexStatus(db: Db, dbPath: string, sourceId: SessionSourceId): IndexMetadata["index"] {
+  const counts = !tableExists(db, "sessions")
+    ? emptyIndexCounts()
+    : !tableColumnExists(db, "sessions", "source_id")
+      ? sourceId === "codex"
+        ? getLegacyCodexStatsCounts(db)
+        : emptyIndexCounts()
+      : getStatsCounts(db, sourceId);
+  return {
+    exists: true,
+    sessionCount: counts.sessionCount,
+    messageCount: counts.messageCount,
+    earliestStartedAt: counts.earliestStartedAt,
+    latestEndedAt: counts.latestEndedAt,
+    dbSizeBytes: dbFileSize(dbPath),
+    lastSyncAt: counts.lastSyncAt,
+  };
+}
+
+function listCoverageRecordsForStatus(db: Db, sourceId: SessionSourceId): CoverageRecord[] {
+  if (!tableColumnExists(db, "coverage", "source_id")) return [];
+  return listCoverageRecords(db, sourceId);
+}
+
+function getLegacyCodexStatsCounts(db: Db): ReturnType<typeof getStatsCounts> {
+  return db
+    .prepare(`
+      SELECT
+        COUNT(*) AS sessionCount,
+        COALESCE(SUM(message_count), 0) AS messageCount,
+        MIN(started_at) AS earliestStartedAt,
+        MAX(ended_at) AS latestEndedAt,
+        MAX(updated_at) AS lastSyncAt
+      FROM sessions
+    `)
+    .get() as ReturnType<typeof getStatsCounts>;
+}
+
+function tableColumnExists(db: Db, tableName: string, columnName: string): boolean {
+  return db
+    .prepare<[string, string], { name: string }>(`
+      SELECT name
+      FROM pragma_table_info(?)
+      WHERE name = ?
+      LIMIT 1
+    `)
+    .get(tableName, columnName) !== undefined;
+}

--- a/src/index-sidecar.test.ts
+++ b/src/index-sidecar.test.ts
@@ -81,7 +81,7 @@ describe("index sidecar", () => {
     parsed.dbIdentity.sqliteSize += 1;
     writeFileSync(sidecarPath, `${JSON.stringify(parsed)}\n`);
 
-    const metadata = loadIndexMetadata(dbPath, "codex");
+    const metadata = await loadIndexMetadata(dbPath, "codex");
     expect(metadata.opened).toBe(true);
     expect(metadata.coverageRecords).toHaveLength(1);
 
@@ -92,6 +92,23 @@ describe("index sidecar", () => {
     });
     expect(status.requestedCoverage?.freshness).toBe("fresh");
     expect(getLastCoverageProbeStats()?.dbOpens).toBe(1);
+  });
+
+  test("empty WAL leftover does not invalidate a matching sidecar", async () => {
+    const { root, dbPath } = writeCodexFixture("sidecar-empty-wal");
+    await syncSessions({ dbPath, selector: { kind: "all", root } });
+    writeFileSync(`${dbPath}-wal`, "");
+
+    const sidecar = readIndexSidecar(dbPath);
+    expect(sidecar).not.toBeNull();
+
+    const status = await collectStatus({
+      rootDir: root,
+      dbPath,
+      selector: { kind: "all", root },
+    });
+    expect(status.requestedCoverage?.freshness).toBe("fresh");
+    expect(getLastCoverageProbeStats()?.dbOpens).toBe(0);
   });
 
   test("corrupt sidecar falls back to SQLite", async () => {

--- a/src/index-sidecar.ts
+++ b/src/index-sidecar.ts
@@ -1,15 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, parse, resolve } from "node:path";
-import { INDEX_VERSION } from "./env";
-import {
-  buildSourceFileMetaResolver,
-  getStatsCounts,
-  listCoverageRecords,
-  loadSourceFileMetaCache,
-  withReadDb,
-  type Db,
-} from "./db";
-import { tableExists } from "./db/sql";
+import { buildSourceFileMetaResolver } from "./db/file-meta-cache";
 import type { SourceFileMetaCacheEntry } from "./db/file-meta-cache";
 import type {
   CoverageRecord,
@@ -83,7 +74,7 @@ export function dbIdentitiesMatch(left: IndexSidecarDbIdentity, right: IndexSide
     && left.walSize === right.walSize;
 }
 
-export function loadIndexMetadata(dbPath: string, sourceId: SessionSourceId): IndexMetadata {
+export async function loadIndexMetadata(dbPath: string, sourceId: SessionSourceId): Promise<IndexMetadata> {
   if (!existsSync(dbPath)) {
     return {
       opened: false,
@@ -103,43 +94,8 @@ export function loadIndexMetadata(dbPath: string, sourceId: SessionSourceId): In
     };
   }
 
-  return withReadDb(dbPath, (db) => ({
-    opened: true,
-    coverageRecords: listCoverageRecordsForStatus(db, sourceId),
-    metaResolver: buildSourceFileMetaResolver(loadSourceFileMetaCache(db, sourceId)),
-    index: readIndexStatus(db, dbPath, sourceId),
-  }));
-}
-
-/**
- * Snapshot metadata from an already-open write connection. Caller must close
- * the connection (and preferably checkpoint WAL) before `writeIndexSidecar`.
- */
-export function snapshotIndexSidecar(db: Db): Omit<IndexSidecar, "writtenAt" | "dbIdentity"> {
-  const sources: IndexSidecar["sources"] = {};
-  for (const sourceId of SESSION_SOURCE_IDS) {
-    const counts = tableExists(db, "sessions")
-      ? tableColumnExists(db, "sessions", "source_id")
-        ? getStatsCounts(db, sourceId)
-        : sourceId === "codex"
-          ? getLegacyCodexStatsCounts(db)
-          : emptyIndexCounts()
-      : emptyIndexCounts();
-    sources[sourceId] = {
-      ...counts,
-      coverageRecords: listCoverageRecordsForStatus(db, sourceId),
-      fileMeta: serializeFileMeta(loadSourceFileMetaCache(db, sourceId)),
-    };
-  }
-  return {
-    version: INDEX_SIDECAR_VERSION,
-    indexVersion: INDEX_VERSION,
-    sources,
-  };
-}
-
-export function checkpointIndexWal(db: Db): void {
-  db.pragma("wal_checkpoint(TRUNCATE)");
+  const { loadIndexMetadataFromSqlite } = await import("./index-sidecar-sqlite");
+  return loadIndexMetadataFromSqlite(dbPath, sourceId);
 }
 
 export function writeIndexSidecar(
@@ -153,28 +109,6 @@ export function writeIndexSidecar(
     dbIdentity: readDbIdentity(dbPath),
   };
   atomicWriteJson(sidecarPath, payload);
-}
-
-/**
- * Dual-write helper for sync: snapshot while the write connection is open,
- * checkpoint WAL, close, then atomically replace the sidecar. A sidecar
- * failure must not fail a completed sync — the next status falls back to
- * SQLite when identity does not match.
- */
-export function persistIndexSidecarAfterWrite(db: Db, dbPath: string): void {
-  const snapshot = snapshotIndexSidecar(db);
-  try {
-    checkpointIndexWal(db);
-  } catch {
-    // Identity includes the WAL file, so a failed checkpoint is still safe.
-  }
-  db.close();
-  try {
-    writeIndexSidecar(dbPath, snapshot);
-  } catch {
-    // Projection only. Status/find reopen SQLite when the sidecar is absent
-    // or its db identity no longer matches.
-  }
 }
 
 export function readIndexSidecar(dbPath: string): IndexSidecar | null {
@@ -191,6 +125,26 @@ export function readIndexSidecar(dbPath: string): IndexSidecar | null {
   return parsed;
 }
 
+export function emptyIndexStatus(): StatusSummary["index"] {
+  return {
+    exists: false,
+    sessionCount: 0,
+    messageCount: 0,
+    earliestStartedAt: null,
+    latestEndedAt: null,
+    dbSizeBytes: 0,
+    lastSyncAt: null,
+  };
+}
+
+export function dbFileSize(dbPath: string): number {
+  try {
+    return statSync(dbPath).size;
+  } catch {
+    return 0;
+  }
+}
+
 function fileIdentity(path: string, kind: "sqlite"): Pick<IndexSidecarDbIdentity, "sqliteMtimeMs" | "sqliteSize">;
 function fileIdentity(path: string, kind: "wal"): Pick<IndexSidecarDbIdentity, "walMtimeMs" | "walSize">;
 function fileIdentity(
@@ -199,8 +153,14 @@ function fileIdentity(
 ): Pick<IndexSidecarDbIdentity, "sqliteMtimeMs" | "sqliteSize"> | Pick<IndexSidecarDbIdentity, "walMtimeMs" | "walSize"> {
   const missing = !existsSync(path);
   const stats = missing ? null : statSync(path);
-  const mtimeMs = stats ? Math.round(stats.mtimeMs) : 0;
   const size = stats ? stats.size : 0;
+  // A missing WAL and a leftover 0-byte WAL are the same: no uncheckpointed
+  // writes. Touching an empty WAL (readers, checkpoint leftovers) must not
+  // invalidate the sidecar, or status falls back and loads the native addon.
+  if (kind === "wal" && (missing || size === 0)) {
+    return { walMtimeMs: 0, walSize: 0 };
+  }
+  const mtimeMs = stats ? Math.round(stats.mtimeMs) : 0;
   return kind === "sqlite"
     ? { sqliteMtimeMs: mtimeMs, sqliteSize: size }
     : { walMtimeMs: mtimeMs, walSize: size };
@@ -220,10 +180,6 @@ function fileMetaMap(entries: IndexSidecarFileMeta[]): Map<string, SourceFileMet
   return cache;
 }
 
-function serializeFileMeta(cache: Map<string, SourceFileMetaCacheEntry>): IndexSidecarFileMeta[] {
-  return [...cache.entries()].map(([filePath, entry]) => ({ filePath, ...entry }));
-}
-
 function indexStatusFromSlice(dbPath: string, slice: IndexSidecarSourceSlice | undefined): StatusSummary["index"] {
   return {
     exists: true,
@@ -234,85 +190,6 @@ function indexStatusFromSlice(dbPath: string, slice: IndexSidecarSourceSlice | u
     dbSizeBytes: dbFileSize(dbPath),
     lastSyncAt: slice?.lastSyncAt ?? null,
   };
-}
-
-function emptyIndexStatus(): StatusSummary["index"] {
-  return {
-    exists: false,
-    sessionCount: 0,
-    messageCount: 0,
-    earliestStartedAt: null,
-    latestEndedAt: null,
-    dbSizeBytes: 0,
-    lastSyncAt: null,
-  };
-}
-
-function emptyIndexCounts(): ReturnType<typeof getStatsCounts> {
-  return {
-    sessionCount: 0,
-    messageCount: 0,
-    earliestStartedAt: null,
-    latestEndedAt: null,
-    lastSyncAt: null,
-  };
-}
-
-function readIndexStatus(db: Db, dbPath: string, sourceId: SessionSourceId): StatusSummary["index"] {
-  const counts = !tableExists(db, "sessions")
-    ? emptyIndexCounts()
-    : !tableColumnExists(db, "sessions", "source_id")
-      ? sourceId === "codex"
-        ? getLegacyCodexStatsCounts(db)
-        : emptyIndexCounts()
-      : getStatsCounts(db, sourceId);
-  return {
-    exists: true,
-    sessionCount: counts.sessionCount,
-    messageCount: counts.messageCount,
-    earliestStartedAt: counts.earliestStartedAt,
-    latestEndedAt: counts.latestEndedAt,
-    dbSizeBytes: dbFileSize(dbPath),
-    lastSyncAt: counts.lastSyncAt,
-  };
-}
-
-function listCoverageRecordsForStatus(db: Db, sourceId: SessionSourceId): CoverageRecord[] {
-  if (!tableColumnExists(db, "coverage", "source_id")) return [];
-  return listCoverageRecords(db, sourceId);
-}
-
-function getLegacyCodexStatsCounts(db: Db): ReturnType<typeof getStatsCounts> {
-  return db
-    .prepare(`
-      SELECT
-        COUNT(*) AS sessionCount,
-        COALESCE(SUM(message_count), 0) AS messageCount,
-        MIN(started_at) AS earliestStartedAt,
-        MAX(ended_at) AS latestEndedAt,
-        MAX(updated_at) AS lastSyncAt
-      FROM sessions
-    `)
-    .get() as ReturnType<typeof getStatsCounts>;
-}
-
-function tableColumnExists(db: Db, tableName: string, columnName: string): boolean {
-  return db
-    .prepare<[string, string], { name: string }>(`
-      SELECT name
-      FROM pragma_table_info(?)
-      WHERE name = ?
-      LIMIT 1
-    `)
-    .get(tableName, columnName) !== undefined;
-}
-
-function dbFileSize(dbPath: string): number {
-  try {
-    return statSync(dbPath).size;
-  } catch {
-    return 0;
-  }
 }
 
 function atomicWriteJson(filePath: string, value: unknown): void {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -19,7 +19,7 @@ import {
   replaceSession,
   upsertSourceFileMetaCache,
 } from "./db";
-import { persistIndexSidecarAfterWrite } from "./index-sidecar";
+import { persistIndexSidecarAfterWrite } from "./index-sidecar-sqlite";
 import { canonicalizeSelector, selectorSource } from "./selector";
 import { getSessionSourceAdapter } from "./sources";
 import { SourceInventoryError } from "./source-inventory";

--- a/src/process-floor.test.ts
+++ b/src/process-floor.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { createRequire } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getLastCoverageProbeStats } from "./coverage-freshness";
+import { INDEX_VERSION } from "./env";
+import {
+  INDEX_SIDECAR_VERSION,
+  loadIndexMetadata,
+  writeIndexSidecar,
+} from "./index-sidecar";
+import { collectStatus } from "./status";
+
+const require = createRequire(import.meta.url);
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function sqliteRequireCacheHits(): string[] {
+  return Object.keys(require.cache).filter((key) => key.includes("better-sqlite3"));
+}
+
+describe("process floor: status does not load better-sqlite3", () => {
+  test("sidecar-backed status never loads the native addon until a db is opened", async () => {
+    const { root, dbPath } = writeSidecarOnlyFixture();
+
+    expect(sqliteRequireCacheHits()).toEqual([]);
+
+    const metadata = await loadIndexMetadata(dbPath, "codex");
+    expect(metadata.opened).toBe(false);
+    expect(metadata.index.exists).toBe(true);
+    expect(metadata.index.sessionCount).toBe(0);
+
+    const status = await collectStatus({
+      rootDir: root,
+      dbPath,
+      selector: { kind: "all", root },
+    });
+    expect(status.index.exists).toBe(true);
+    expect(getLastCoverageProbeStats()?.dbOpens).toBe(0);
+    expect(sqliteRequireCacheHits()).toEqual([]);
+
+    const { openWriteDb, sqliteNativeModuleLoaded } = await import("./db/connection");
+    expect(sqliteNativeModuleLoaded()).toBe(false);
+
+    const db = openWriteDb(join(root, "..", "opened.sqlite"));
+    db.close();
+    expect(sqliteNativeModuleLoaded()).toBe(true);
+    expect(sqliteRequireCacheHits().length).toBeGreaterThan(0);
+  });
+});
+
+function writeSidecarOnlyFixture(): { root: string; dbPath: string } {
+  const base = mkdtempSync(join(tmpdir(), "cxs-process-floor-"));
+  tempDirs.push(base);
+  const root = join(base, "sessions");
+  mkdirSync(root, { recursive: true });
+  const dbPath = join(base, "index.sqlite");
+  writeFileSync(dbPath, "");
+  writeIndexSidecar(dbPath, {
+    version: INDEX_SIDECAR_VERSION,
+    indexVersion: INDEX_VERSION,
+    sources: {
+      codex: {
+        sessionCount: 0,
+        messageCount: 0,
+        earliestStartedAt: null,
+        latestEndedAt: null,
+        lastSyncAt: null,
+        coverageRecords: [],
+        fileMeta: [],
+      },
+    },
+  });
+  return { root, dbPath };
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,7 @@
 export { buildQuerySignals } from "./ranking";
 export { findSessions } from "./query/find";
-export { getMessagePage, getMessageRange, SessionNotFoundError } from "./query/read";
+export { getMessagePage, getMessageRange } from "./query/read";
+export { SessionNotFoundError } from "./query/session-not-found";
 export { listSessionSummaries } from "./query/list";
 export { collectStats } from "./query/stats";
 export { isCjkTerm } from "./query/cjk";

--- a/src/query/read.ts
+++ b/src/query/read.ts
@@ -1,24 +1,12 @@
 import { coverageEntriesForSession, getMessagesForPage, getMessagesForRange, getSessionRecord, withSourceAwareReadDb } from "../db";
 import { rerankHits } from "../ranking";
-import { DEFAULT_SESSION_SOURCE_ID, isSessionSourceId, type FindResult, type SessionRecord, type SessionSourceId } from "../types";
+import type { FindResult, SessionRecord } from "../types";
 import type { Db } from "../db";
 import { elideMessages } from "./message-elision";
 import { searchMessageHits } from "./search";
+import { SessionNotFoundError } from "./session-not-found";
 
-export class SessionNotFoundError extends Error {
-  sessionRef: string;
-  sourceId: SessionSourceId;
-  nativeSessionId: string;
-
-  constructor(sessionRef: string) {
-    const identity = parseSessionRef(sessionRef);
-    super(`session not found in Sherlog index: ${sessionRef}`);
-    this.name = "SessionNotFoundError";
-    this.sessionRef = sessionRef;
-    this.sourceId = identity.sourceId;
-    this.nativeSessionId = identity.nativeSessionId;
-  }
-}
+export { SessionNotFoundError } from "./session-not-found";
 
 export function getMessageRange(
   dbPath: string,
@@ -118,12 +106,3 @@ function searchTopHitInSession(db: Db, session: SessionRecord, query: string): F
   return result ?? null;
 }
 
-function parseSessionRef(sessionRef: string): { sourceId: SessionSourceId; nativeSessionId: string } {
-  const separator = sessionRef.indexOf(":");
-  if (separator > 0) {
-    const sourceId = sessionRef.slice(0, separator);
-    const nativeSessionId = sessionRef.slice(separator + 1);
-    if (isSessionSourceId(sourceId)) return { sourceId, nativeSessionId };
-  }
-  return { sourceId: DEFAULT_SESSION_SOURCE_ID, nativeSessionId: sessionRef };
-}

--- a/src/query/session-not-found.ts
+++ b/src/query/session-not-found.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_SESSION_SOURCE_ID, isSessionSourceId, type SessionSourceId } from "../types";
+
+export class SessionNotFoundError extends Error {
+  sessionRef: string;
+  sourceId: SessionSourceId;
+  nativeSessionId: string;
+
+  constructor(sessionRef: string) {
+    const identity = parseSessionRef(sessionRef);
+    super(`session not found in Sherlog index: ${sessionRef}`);
+    this.name = "SessionNotFoundError";
+    this.sessionRef = sessionRef;
+    this.sourceId = identity.sourceId;
+    this.nativeSessionId = identity.nativeSessionId;
+  }
+}
+
+export function parseSessionRef(sessionRef: string): { sourceId: SessionSourceId; nativeSessionId: string } {
+  const separator = sessionRef.indexOf(":");
+  if (separator > 0) {
+    const sourceId = sessionRef.slice(0, separator);
+    const nativeSessionId = sessionRef.slice(separator + 1);
+    if (isSessionSourceId(sourceId)) return { sourceId, nativeSessionId };
+  }
+  return { sourceId: DEFAULT_SESSION_SOURCE_ID, nativeSessionId: sessionRef };
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -36,7 +36,7 @@ export async function collectStatus(options: {
   const dbPath = options.dbPath ?? DEFAULT_DB_PATH;
   const stats = emptyCoverageProbeStats();
   const dbStarted = performance.now();
-  const dbState = loadIndexMetadata(dbPath, source.id);
+  const dbState = await loadIndexMetadata(dbPath, source.id);
   stats.dbMs = performance.now() - dbStarted;
   stats.dbOpens = dbState.opened ? 1 : 0;
 


### PR DESCRIPTION
## Summary
- `better-sqlite3` is lazy-required on the first `openReadDb` / `openWriteDb`. `--version` and sidecar-hit `status` no longer `dlopen` the native addon.
- Sidecar JSON read stays in `index-sidecar.ts`; SQLite snapshot/persist/fallback moved to `index-sidecar-sqlite.ts`. CLI no longer statically imports the query/indexer/db barrel.
- An empty leftover WAL is treated as missing, so sidecar identity stays valid on live indexes (a 0-byte WAL mtime no longer forces a SQLite fallback).

## Test plan
- [x] `npm run check` (254 tests)
- [x] Bundled `dist/cli.js` has no static `from "better-sqlite3"` import
- [x] Live Codex: `DYLD_PRINT_LIBRARIES` shows no `better_sqlite3.node` on `--version` or sidecar-hit `status --selector`
- [ ] CI green
- [ ] After merge: bump 0.4.3, tag, wait for npm, update PATH CLI + skill + changelog site


Made with [Cursor](https://cursor.com)