### PR TITLE
fix: ranking/elision for dogfood C-fails and ship 0.4.4

### DIFF
--- a/eval/dogfood-eval-core.test.ts
+++ b/eval/dogfood-eval-core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { desiredContextMode, evaluateDogfoodItem, missingContextNeedles, selectDogfoodHit } from "./dogfood-eval-core";
+import { buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, selectDogfoodHit } from "./dogfood-eval-core";
 import { parseDogfoodJsonl } from "./dogfood-schema";
 import type { DogfoodGolden } from "./dogfood-schema";
 import type { FindResult } from "../src/types";
@@ -110,6 +110,35 @@ describe("dogfood eval core", () => {
 
     expect(desiredContextMode(item, findResult({ matchSource: "message", matchSeq: 7 }))).toBe("read-range");
     expect(desiredContextMode(item, findResult({ matchSource: "session", matchSeq: null }))).toBe("read-range");
+  });
+
+  test("keeps --query next to --seq so elision can preserve the evidence span", () => {
+    expect(buildReadRangeContextArgs({
+      sessionRef: "session-a",
+      matchSeq: 6,
+      query: "node dist/cli.js publish",
+      before: 2,
+      after: 4,
+    })).toEqual([
+      "read-range", "session-a",
+      "--seq", "6",
+      "--query", "node dist/cli.js publish",
+      "--before", "2",
+      "--after", "4",
+    ]);
+
+    expect(buildReadRangeContextArgs({
+      sessionRef: "session-b",
+      matchSeq: null,
+      query: "ping pong",
+      before: 2,
+      after: 2,
+    })).toEqual([
+      "read-range", "session-b",
+      "--query", "ping pong",
+      "--before", "2",
+      "--after", "2",
+    ]);
   });
 
   test("reports missing context needles case-insensitively", () => {

--- a/eval/dogfood-eval-core.test.ts
+++ b/eval/dogfood-eval-core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, selectDogfoodHit } from "./dogfood-eval-core";
+import { buildFindCliArgs, buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, selectDogfoodHit } from "./dogfood-eval-core";
 import { parseDogfoodJsonl } from "./dogfood-schema";
 import type { DogfoodGolden } from "./dogfood-schema";
 import type { FindResult } from "../src/types";
@@ -110,6 +110,20 @@ describe("dogfood eval core", () => {
 
     expect(desiredContextMode(item, findResult({ matchSource: "message", matchSeq: 7 }))).toBe("read-range");
     expect(desiredContextMode(item, findResult({ matchSource: "session", matchSeq: null }))).toBe("read-range");
+  });
+
+  test("passes find.cwd as --cwd instead of a Codex-only --selector", () => {
+    expect(buildFindCliArgs({
+      query: "Claude Code",
+      limit: 5,
+      cwd: "/Users/envvar/work/repos/cxs",
+      excludeSessionUuids: ["self"],
+    })).toEqual([
+      "find", "Claude Code",
+      "--limit", "5",
+      "--cwd", "/Users/envvar/work/repos/cxs",
+      "--exclude-session", "self",
+    ]);
   });
 
   test("keeps --query next to --seq so elision can preserve the evidence span", () => {

--- a/eval/dogfood-eval-core.ts
+++ b/eval/dogfood-eval-core.ts
@@ -99,6 +99,25 @@ export function selectDogfoodHit(item: DogfoodGolden, results: FindResult[]): Se
  * and still pass --query so large-message elision uses around_query instead
  * of head_tail. Session-only hits omit --seq and locate via --query.
  */
+/** Mirror a real agent find: pass --cwd, not a Codex-only --selector. */
+export function buildFindCliArgs(input: {
+  query: string;
+  limit: number;
+  sort?: string;
+  cwd?: string;
+  selector?: { kind: string };
+  excludeSessionUuids?: string[];
+}): string[] {
+  const args = ["find", input.query, "--limit", String(input.limit)];
+  if (input.sort) args.push("--sort", input.sort);
+  if (input.selector) args.push("--selector", JSON.stringify(input.selector));
+  else if (input.cwd) args.push("--cwd", input.cwd);
+  for (const sessionUuid of input.excludeSessionUuids ?? []) {
+    args.push("--exclude-session", sessionUuid);
+  }
+  return args;
+}
+
 export function buildReadRangeContextArgs(input: {
   sessionRef: string;
   matchSeq: number | null;

--- a/eval/dogfood-eval-core.ts
+++ b/eval/dogfood-eval-core.ts
@@ -94,6 +94,25 @@ export function selectDogfoodHit(item: DogfoodGolden, results: FindResult[]): Se
   return { hit: results[0] ?? null, rank: results.length > 0 ? 1 : null, topK };
 }
 
+/**
+ * Mirror evidenceRead.argv for message hits: keep --seq as the stable anchor
+ * and still pass --query so large-message elision uses around_query instead
+ * of head_tail. Session-only hits omit --seq and locate via --query.
+ */
+export function buildReadRangeContextArgs(input: {
+  sessionRef: string;
+  matchSeq: number | null;
+  query?: string;
+  before: number;
+  after: number;
+}): string[] {
+  const args = ["read-range", input.sessionRef];
+  if (typeof input.matchSeq === "number") args.push("--seq", String(input.matchSeq));
+  if (input.query) args.push("--query", input.query);
+  args.push("--before", String(input.before), "--after", String(input.after));
+  return args;
+}
+
 export function desiredContextMode(item: DogfoodGolden, hit: FindResult | null): "read-range" | "read-page" | null {
   const context = item.expected.context;
   if (!context?.mustContain?.length && !item.expected.answerFacets?.length) return null;

--- a/eval/run-dogfood-eval.ts
+++ b/eval/run-dogfood-eval.ts
@@ -3,9 +3,8 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn as childSpawn } from "node:child_process";
 import { basename, join, resolve } from "node:path";
-import { buildDogfoodScoreboard, buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
+import { buildDogfoodScoreboard, buildFindCliArgs, buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
 import { parseDogfoodJsonl, type DogfoodGolden } from "./dogfood-schema";
-import { DEFAULT_CODEX_DIR } from "../src/env";
 import type { FindResult, FindSort, Selector } from "../src/types";
 
 interface FindOutput {
@@ -23,6 +22,7 @@ interface FindAttemptSpec {
   query: string;
   limit: number;
   sort?: FindSort;
+  cwd?: string;
   selector?: Selector;
   excludeSessionUuids: string[];
 }
@@ -144,7 +144,7 @@ async function runFindAttempts(
 function buildFindAttemptSpecs(item: DogfoodGolden): FindAttemptSpec[] {
   const options = item.find ?? {};
   const queries = uniqueNonEmpty(options.queries?.length ? options.queries : [item.query]);
-  const selector = options.selector ?? selectorFromCwd(options.cwd, options.root);
+  const selector = options.selector;
   const limit = Math.max(item.expected.topK ?? 5, options.limit ?? 0, 5);
   const excludeSessionUuids = uniqueNonEmpty(options.excludeSessionUuids ?? []);
 
@@ -153,22 +153,23 @@ function buildFindAttemptSpecs(item: DogfoodGolden): FindAttemptSpec[] {
     query,
     limit,
     ...(options.sort ? { sort: options.sort } : {}),
-    ...(selector ? { selector } : {}),
+    ...(selector ? { selector } : options.cwd ? { cwd: options.cwd } : {}),
     excludeSessionUuids,
   }));
 }
 
-function selectorFromCwd(cwd: string | undefined, root: string | undefined): Selector | undefined {
-  if (!cwd) return undefined;
-  return { kind: "cwd", root: resolve(root ?? DEFAULT_CODEX_DIR), cwd };
-}
-
 function buildFindCommand(spec: FindAttemptSpec): string[] {
-  const command = [process.execPath, "--import", "tsx", CLI_ENTRY, "find", spec.query, "--limit", String(spec.limit)];
-  if (spec.sort) command.push("--sort", spec.sort);
-  if (spec.selector) command.push("--selector", JSON.stringify(spec.selector));
-  for (const sessionUuid of spec.excludeSessionUuids) command.push("--exclude-session", sessionUuid);
-  return command;
+  return [
+    process.execPath, "--import", "tsx", CLI_ENTRY,
+    ...buildFindCliArgs({
+      query: spec.query,
+      limit: spec.limit,
+      sort: spec.sort,
+      cwd: spec.cwd,
+      selector: spec.selector,
+      excludeSessionUuids: spec.excludeSessionUuids,
+    }),
+  ];
 }
 
 function uniqueNonEmpty(values: string[]): string[] {

--- a/eval/run-dogfood-eval.ts
+++ b/eval/run-dogfood-eval.ts
@@ -3,7 +3,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn as childSpawn } from "node:child_process";
 import { basename, join, resolve } from "node:path";
-import { buildDogfoodScoreboard, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
+import { buildDogfoodScoreboard, buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
 import { parseDogfoodJsonl, type DogfoodGolden } from "./dogfood-schema";
 import { DEFAULT_CODEX_DIR } from "../src/env";
 import type { FindResult, FindSort, Selector } from "../src/types";
@@ -118,7 +118,7 @@ async function runFindAttempts(
 
     const parsedFind = JSON.parse(findJson) as FindOutput;
     const preselected = evaluateDogfoodItem({ item, results: parsedFind.results }).selected;
-    const context = await readContextIfNeeded(item, preselected.hit, prefix, `${safeId}${suffix}`, outDir);
+    const context = await readContextIfNeeded(item, preselected.hit, prefix, `${safeId}${suffix}`, outDir, spec.query);
     const evaluation = evaluateDogfoodItem({
       item,
       results: parsedFind.results,
@@ -193,17 +193,18 @@ async function readContextIfNeeded(
   prefix: string,
   safeId: string,
   outDir: string,
+  attemptQuery: string,
 ): Promise<{ kind?: "read-range" | "read-page"; text?: string; textPath?: string; unavailableReason?: string }> {
   const mode = desiredContextMode(item, hit);
   if (!mode) return {};
   if (!hit) return { unavailableReason: "no selected hit for context read" };
 
-  let command = buildContextCommand(item, hit, mode);
+  let command = buildContextCommand(item, hit, mode, attemptQuery);
   let contextJson = await runCommand([...command, "--json"]);
   let contextText = await runCommand(command);
   let suffix: string = mode;
   if (shouldReadWiderRange(item, mode, contextText)) {
-    command = buildContextCommand(item, hit, mode, { before: 4, after: 8 });
+    command = buildContextCommand(item, hit, mode, attemptQuery, { before: 4, after: 8 });
     contextJson = await runCommand([...command, "--json"]);
     contextText = await runCommand(command);
     suffix = `${mode}.wide`;
@@ -227,19 +228,20 @@ function buildContextCommand(
   item: DogfoodGolden,
   hit: FindResult,
   mode: "read-range" | "read-page",
+  attemptQuery: string,
   defaultWindow: { before: number; after: number } = { before: 2, after: 2 },
 ): string[] {
   const context = item.expected.context ?? {};
   if (mode === "read-range") {
-    const anchorArgs = typeof hit.matchSeq === "number"
-      ? ["--seq", String(hit.matchSeq)]
-      : ["--query", context.query ?? item.query];
     return [
       process.execPath, "--import", "tsx", CLI_ENTRY,
-      "read-range", hit.sessionRef,
-      ...anchorArgs,
-      "--before", String(context.before ?? defaultWindow.before),
-      "--after", String(context.after ?? defaultWindow.after),
+      ...buildReadRangeContextArgs({
+        sessionRef: hit.sessionRef,
+        matchSeq: hit.matchSeq,
+        query: context.query ?? attemptQuery,
+        before: context.before ?? defaultWindow.before,
+        after: context.after ?? defaultWindow.after,
+      }),
     ];
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@act0r/sherlog",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@act0r/sherlog",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@act0r/sherlog",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "Progressive search CLI for local Codex, Claude Code, and Pi session logs",
   "license": "MIT",

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -199,6 +199,23 @@
   <main>
     <section>
       <div class="release-header">
+        <span class="release-version">v0.4.4</span>
+        <span class="release-date">2026-08-14</span>
+      </div>
+      <ul class="en">
+        <li><strong>Path-like command ranking.</strong> A later title that restates <code>node dist/cli.js publish</code> no longer outranks the session that actually ran the command.</li>
+        <li><strong>Large-message reads keep the query window.</strong> <code>read-range --query</code> still centers on the match, and also keeps a short leading slice so <code>cd /path</code> and table headers survive. Dogfood / skill now keep <code>--query</code> next to <code>--seq</code>.</li>
+        <li>Skill: <code>--sort ended</code> is not a date filter; short product names need <code>--cwd</code> or a more distinctive phrase.</li>
+      </ul>
+      <ul class="zh">
+        <li><strong>Path-like 命令排序。</strong>后来用标题复述 <code>node dist/cli.js publish</code> 的会话，不再压过真正执行过这条命令的会话。</li>
+        <li><strong>大消息读取保住 query 窗口。</strong><code>read-range --query</code> 仍以命中为中心，并保留一小段文首，避免 <code>cd /path</code> 和表头被裁掉。Dogfood / skill 会把 <code>--query</code> 和 <code>--seq</code> 一起带上。</li>
+        <li>Skill：<code>--sort ended</code> 不是日期窗；短产品名要加 <code>--cwd</code>，或改用更独特的短语。</li>
+      </ul>
+    </section>
+
+    <section>
+      <div class="release-header">
         <span class="release-version">v0.4.3</span>
         <span class="release-date">2026-08-14</span>
       </div>

--- a/skill-packages/sherlog/SKILL.md
+++ b/skill-packages/sherlog/SKILL.md
@@ -28,8 +28,8 @@ description: "Use proactively for local agent-session history and prior setup ar
 | policy | rule |
 | --- | --- |
 | Evidence | `find/list` 只定位候选；内容先执行 `evidenceRead.argv` / `read-*`。只有 index projection 明确缺少完整 tool call、patch、长代码或原始事件时，才在定位 session 后走 agent-side raw fallback。 |
-| Provenance | 读结果时先看 `matchedFields`（命中出处）与 `sessionMessageCount`（读取成本上限）再决定 read 策略：message 锚点走 `read-range`，session-level 命中信 `evidenceRead`，大 session 避免盲目全量 `read-page`。 |
-| Sort | `find` 默认 relevance；用户问最新/最近时用 `--sort ended`，必要时 `--exclude-session` 排除 self-hit。 |
+| Provenance | 读结果时先看 `matchedFields`（命中出处）与 `sessionMessageCount`（读取成本上限）再决定 read 策略：message 锚点走 `read-range`，session-level 命中信 `evidenceRead`，大 session 避免盲目全量 `read-page`。始终执行完整 `evidenceRead.argv`（含 `--query`）；有 elision 且关键句不可见时，同一命令加 `--max-message-chars 0`。 |
+| Sort | `find` 默认 relevance；用户问最新/最近时用 `--sort ended`，必要时 `--exclude-session` 排除 self-hit。`--sort ended` 只按命中 session 的 `endedAt` 排序，不是日期窗；query 里的「最近一个星期」只是 FTS 词。短产品名或通用文件名先加 `--cwd` 或改用更独特短语。 |
 | Zero results | 先读 `zeroResults.reason`：`fresh_miss` 可信，按 `suggestedQueries` 放宽后再下结论；`stale_or_missing_coverage` 不可信，按 `nextAction` 同范围 sync 再重试；`coverage_not_confirmed` 先 `status`。不要对同一过长 query 原样重试。 |
 | Coverage | 跟随同范围 `nextAction`。Codex `source_content_changed` + `recommendedAction: "query"` 是 soft stale：先 query/read；只有答案依赖最新活跃尾部时才 sync。 |
 | Cold | `cold add` 只注册 presence 供 prune 保留。`sync` 只摄取 plain `*.jsonl`；不会从 cold `*.jsonl.zst` 重建 index。 |

--- a/skill-packages/sherlog/references/failure-cookbook.md
+++ b/skill-packages/sherlog/references/failure-cookbook.md
@@ -17,6 +17,8 @@ Apply `SKILL.md` **Canonical policy**. This file maps failures to recovery actio
 | 冷迁后担心历史丢了 | `find/list/read-*` | 默认 retain；确认 cold 已注册。完整 raw 细节走 progressive raw fallback |
 | `database is locked` | 重试一次 | 仍忙则跳过 `stats`，稍后重试读命令 |
 | 同主题多 uuid | `find -n 10 --json` | 按 `startedAt` / `cwd` / `matchCount` 选，再执行 `evidenceRead` |
+| 短产品名/通用文件名被新提及淹没 | `find "<distinct phrase>" --cwd <repo-cwd> --json` | 不要把 `--sort ended` 或 query 里的「最近一周」当成日期过滤 |
+| read 有 elision 但缺关键句 | 原 `evidenceRead.argv` 加 `--max-message-chars 0` | 不要丢掉 `--query`；`around_query` 依赖它 |
 | metadata 问题却 broad find/status | 只读 SQLite + `read-*` | 标 `skill-guidance-issue`，改用 metadata primitive |
 | CJK 零结果 | 换词 | ≥2 字中文、英文标识符、或缩 selector |
 | `unsupported_source` | 修正 source id | public: `codex` / experimental `claude-code` / `pi` |

--- a/skill-packages/sherlog/references/progressive-workflow.md
+++ b/skill-packages/sherlog/references/progressive-workflow.md
@@ -27,6 +27,8 @@ sqlite3 -readonly "$DB_PATH" \
 "${SHLOG_BIN:-${CXS_BIN:-shlog}}" find "cf tunnel" --json -n 5
 ```
 
+短产品名（两个英文词）或通用文件名单独作 query 时加 `--cwd`，或改用更长独特短语；否则跨源默认 find 容易被近期配置闲聊占满。
+
 选候选时用 `matchedFields`（命中出处：message 证据强于 title/compact/reasoningSummary）和 `sessionMessageCount`（读取成本上限）辅助判断；零结果时按 `zeroResults.reason` 分流（见 failure-cookbook）。对候选始终执行 `evidenceRead.argv`；不要根据 `matchSeq` 自己重建命令。示例形状可能是：
 
 ```bash

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2020,7 +2020,7 @@ describe("shlog cli", { timeout: 20_000 }, () => {
     expect(message.timestamp).toBe("2026-04-21T00:00:00.000Z");
     expect(message.sessionUuid).toBe("99999999-9999-4999-8999-999999999999");
     expect(message.contentText).toContain("evidence");
-    expect(message.contentText.length).toBeLessThan(1_000);
+    expect(message.contentText.length).toBeLessThan(1_200);
     expect(message.elision).toMatchObject({
       originalCharCount: huge.length,
       strategy: "around_query",

--- a/src/query-session-ranking.test.ts
+++ b/src/query-session-ranking.test.ts
@@ -161,4 +161,44 @@ describe("cxs session ranking", () => {
     const found = findSessions(dbPath, "node build/cli.js deploy", 5);
     expect(found.results[0]?.sessionUuid).toBe("f2f2f2f2-f2f2-42f2-82f2-f2f2f2f2f2f2");
   });
+
+  test("path-like command query prefers executed invocation over a later title restatement", async () => {
+    const base = mkdtempSync(join(tmpdir(), "cxs-command-restate-"));
+    tempDirs.push(base);
+    const sessionsRoot = join(base, "sessions", "2026", "05", "01");
+    mkdirSync(sessionsRoot, { recursive: true });
+
+    writeFileSync(
+      join(sessionsRoot, "rollout-2026-05-01T09-00-00-a1a1a1a1-a1a1-41a1-81a1-a1a1a1a1a1a1.jsonl"),
+      [
+        line("session_meta", { id: "a1a1a1a1-a1a1-41a1-81a1-a1a1a1a1a1a1", cwd: "/tmp/what7" }),
+        line("turn_context", { model: "gpt-5.4" }),
+        line("event_msg", { type: "user_message", message: "怎么使用" }),
+        line("event_msg", {
+          type: "agent_message",
+          message: "cd /tmp/what7 后运行 node dist/cli.js publish fixtures/sample.jsonl --json",
+        }),
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(sessionsRoot, "rollout-2026-05-02T09-00-00-b2b2b2b2-b2b2-42b2-82b2-b2b2b2b2b2b2.jsonl"),
+      [
+        line("session_meta", { id: "b2b2b2b2-b2b2-42b2-82b2-b2b2b2b2b2b2", cwd: "/tmp/play" }),
+        line("turn_context", { model: "gpt-5.4" }),
+        line("event_msg", { type: "user_message", message: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的" }),
+        line("event_msg", { type: "agent_message", message: "这是在搜命令对应的仓库，不是一次 publish 调用。" }),
+      ].join("\n"),
+    );
+
+    const dbPath = join(base, "index.sqlite");
+    const summary = await syncSessions({ dbPath, rootDir: join(base, "sessions") });
+    expect(summary.added).toBe(2);
+
+    const found = findSessions(dbPath, "node dist/cli.js publish", 5);
+    expect(found.results.map((result) => result.sessionUuid)).toEqual([
+      "a1a1a1a1-a1a1-41a1-81a1-a1a1a1a1a1a1",
+      "b2b2b2b2-b2b2-42b2-82b2-b2b2b2b2b2b2",
+    ]);
+  });
 });

--- a/src/query/message-elision.test.ts
+++ b/src/query/message-elision.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { DEFAULT_MAX_MESSAGE_CHARS, elideMessages } from "./message-elision";
+import type { MessageRecord } from "../types";
+
+function message(contentText: string, seq = 0): MessageRecord {
+  return {
+    sessionUuid: "sess",
+    seq,
+    role: "user",
+    timestamp: "2026-06-05T08:08:53.465Z",
+    sourceKind: "event_msg",
+    contentText,
+  };
+}
+
+describe("elideMessages", () => {
+  test("around_query keeps a comparison-table row that head_tail would drop", () => {
+    const header = "两个格式的关键差异：\n";
+    const storageRow = "存储位置 │ ~/.codex/sessions/（扁平） │ ~/.claude/projects/<hash>/<uuid>.jsonl（嵌套）\n";
+    const padding = `${"x".repeat(500)}\n`;
+    const structureRow = "对话结构 │ 线性 │ 树形（parentUuid 分支）\n";
+    const tail = "y".repeat(400);
+    const contentText = `${header}${storageRow}${padding}${structureRow}${tail}`;
+    expect(contentText.length).toBeGreaterThan(DEFAULT_MAX_MESSAGE_CHARS);
+
+    const headTail = elideMessages([message(contentText)], { maxMessageChars: DEFAULT_MAX_MESSAGE_CHARS, anchorSeq: 0 });
+    expect(headTail[0]?.elision?.strategy).toBe("head_tail");
+    expect(headTail[0]?.contentText).not.toContain("对话结构 │ 线性 │ 树形（parentUuid 分支）");
+
+    const aroundQuery = elideMessages([message(contentText)], {
+      maxMessageChars: DEFAULT_MAX_MESSAGE_CHARS,
+      anchorSeq: 0,
+      query: "两个格式的关键差异",
+    });
+    expect(aroundQuery[0]?.elision?.strategy).toBe("around_query");
+    expect(aroundQuery[0]?.contentText).toContain("存储位置 │ ~/.codex/sessions/（扁平）");
+    expect(aroundQuery[0]?.contentText).toContain("对话结构 │ 线性 │ 树形（parentUuid 分支）");
+  });
+
+  test("around_query also keeps a leading cd/path when the command match is later in the message", () => {
+    const head = "cd /tmp/what7 && ";
+    const padding = "n".repeat(900);
+    const command = "node dist/cli.js publish fixtures/sample.jsonl --json";
+    const contentText = `${head}${padding}${command}`;
+    expect(contentText.length).toBeGreaterThan(DEFAULT_MAX_MESSAGE_CHARS);
+
+    const aroundQuery = elideMessages([message(contentText)], {
+      maxMessageChars: DEFAULT_MAX_MESSAGE_CHARS,
+      anchorSeq: 0,
+      query: "node dist/cli.js publish",
+    });
+    expect(aroundQuery[0]?.elision?.strategy).toBe("around_query");
+    expect(aroundQuery[0]?.contentText).toContain("cd /tmp/what7");
+    expect(aroundQuery[0]?.contentText).toContain("node dist/cli.js publish fixtures/sample.jsonl --json");
+  });
+});

--- a/src/query/message-elision.ts
+++ b/src/query/message-elision.ts
@@ -63,10 +63,27 @@ function preserveAroundQuery(
   queryLength: number,
 ): { text: string; visibleCharCount: number } {
   const budget = Math.max(maxMessageChars, queryLength);
+  const queryWindow = windowAround(text.length, queryIndex, queryLength, budget);
+  if (queryWindow.start === 0) return markElision(text, queryWindow.start, queryWindow.end);
+
+  // Keep the full query window plus a short leading slice so `cd /path &&`
+  // and table headers survive. Do not shrink the query window: that drops
+  // nearby evidence that already fit in the original around_query span.
+  const headBudget = Math.min(Math.floor(budget / 4), queryWindow.start);
+  if (headBudget < 32) return markElision(text, queryWindow.start, queryWindow.end);
+  if (queryWindow.start <= headBudget) return markElision(text, 0, queryWindow.end);
+  return markElision(text, 0, headBudget, queryWindow.start, queryWindow.end);
+}
+
+function windowAround(
+  textLength: number,
+  queryIndex: number,
+  queryLength: number,
+  budget: number,
+): { start: number; end: number } {
   const start = Math.max(0, queryIndex - Math.floor((budget - queryLength) / 2));
-  const end = Math.min(text.length, start + budget);
-  const adjustedStart = Math.max(0, end - budget);
-  return markElision(text, adjustedStart, end);
+  const end = Math.min(textLength, start + budget);
+  return { start: Math.max(0, end - budget), end };
 }
 
 function preserveHeadTail(text: string, maxMessageChars: number): { text: string; visibleCharCount: number } {

--- a/src/ranking.test.ts
+++ b/src/ranking.test.ts
@@ -123,4 +123,93 @@ describe("rerankHits", () => {
     expect(results).toHaveLength(2);
     expect(results[0].sessionUuid).toBe("sess2");
   });
+
+  test("path-like command query prefers executed invocation over a later title restatement", () => {
+    const executed = makeRow({
+      sessionUuid: "executed-use",
+      title: "怎么使用",
+      cwd: "/tmp/what7",
+      contentText: "cd /tmp/what7 && node dist/cli.js publish fixtures/sample.jsonl --json",
+      matchSource: "message",
+      matchRole: "assistant",
+      endedAt: "2026-05-01T09:12:06.959Z",
+      score: -2,
+    });
+    const restatement = makeRow({
+      sessionUuid: "search-restatement",
+      title: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+      cwd: "/tmp/play",
+      contentText: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+      matchSource: "message",
+      matchRole: "user",
+      endedAt: "2026-05-02T09:00:00.000Z",
+      score: -2,
+    });
+
+    const results = rerankHits([restatement, executed], "node dist/cli.js publish", 5);
+    expect(results[0]?.sessionUuid).toBe("executed-use");
+  });
+
+  test("session-level title+summary concat does not treat a later cli.js copy as command args", () => {
+    const restatement = makeRow({
+      sessionUuid: "search-restatement",
+      title: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+      cwd: "/tmp/play",
+      contentText: [
+        "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+        "user: cxs node dist/cli.js publish 搜下这个是哪个项目路径的 | assistant: 这是在搜命令对应的仓库",
+      ].join("\n"),
+      matchSource: "session",
+      matchRole: "session",
+      score: -2,
+    });
+    const executed = makeRow({
+      sessionUuid: "executed-use",
+      title: "怎么使用",
+      cwd: "/tmp/what7",
+      contentText: "cd /tmp/what7 && node dist/cli.js publish fixtures/sample.jsonl --json",
+      matchSource: "message",
+      matchRole: "assistant",
+      score: -2,
+    });
+
+    const results = rerankHits([restatement, executed], "node dist/cli.js publish", 5);
+    expect(results[0]?.sessionUuid).toBe("executed-use");
+  });
+
+  test("title restatement still loses when the later session quotes the invocation path", () => {
+    const executed = makeRow({
+      sessionUuid: "executed-use",
+      title: "怎么使用",
+      cwd: "/tmp/what7",
+      contentText: "cd /tmp/what7 && node dist/cli.js publish fixtures/sample.jsonl --json",
+      matchSource: "message",
+      matchRole: "assistant",
+      endedAt: "2026-05-01T09:12:06.959Z",
+      score: -2,
+    });
+    const restatement = makeRow({
+      sessionUuid: "search-restatement",
+      title: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+      cwd: "/tmp/play",
+      contentText: "cxs find node dist/cli.js publish 命中的历史 session cwd=/tmp/what7 证据 node dist/cli.js publish fixtures/sample.jsonl --json",
+      matchSource: "message",
+      matchRole: "assistant",
+      endedAt: "2026-05-02T09:00:00.000Z",
+      score: -2,
+    });
+    const restatementUser = makeRow({
+      sessionUuid: "search-restatement",
+      title: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+      cwd: "/tmp/play",
+      contentText: "cxs node dist/cli.js publish 搜下这个是哪个项目路径的",
+      matchSource: "message",
+      matchRole: "user",
+      endedAt: "2026-05-02T09:00:00.000Z",
+      score: -2,
+    });
+
+    const results = rerankHits([restatementUser, restatement, executed], "node dist/cli.js publish", 5);
+    expect(results[0]?.sessionUuid).toBe("executed-use");
+  });
 });

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -63,6 +63,7 @@ interface SessionAggregate {
   titlePhrase: boolean;
   titleTermHits: number;
   cwdTermHits: number;
+  titleRestatement: boolean;
 }
 
 export function rerankHits(rows: RawHitRow[], query: string, limit: number): FindResult[] {
@@ -99,7 +100,8 @@ function createSessionAggregate(row: RawHitRow, signals: QuerySignals, signalSco
     && (signals.isPathLikeCommand
       ? containsBoundedPhrase(rowTitleLower, signals.normalizedQuery)
       : rowTitleLower.includes(signals.normalizedQuery));
-  const titleTermHits = countMatchedTerms(rowTitleLower, signals.terms);
+  const titleRestatement = titleLooksLikeCommandRestatement(rowTitleLower, signals);
+  const titleTermHits = titleRestatement ? 0 : countMatchedTerms(rowTitleLower, signals.terms);
   const cwdTermHits = countMatchedTerms(rowCwdLower, signals.terms);
 
   return {
@@ -111,9 +113,10 @@ function createSessionAggregate(row: RawHitRow, signals: QuerySignals, signalSco
     hitCount: 1,
     sessionHitCount: row.matchSource === "session" ? 1 : 0,
     userHitCount: row.matchRole === "user" ? 1 : 0,
-    titlePhrase,
+    titlePhrase: titlePhrase && !titleRestatement,
     titleTermHits,
     cwdTermHits,
+    titleRestatement,
   };
 }
 
@@ -239,7 +242,8 @@ function scoreSession(aggregate: SessionAggregate, now: number): number {
     + Math.min(aggregate.userHitCount, 3) * 4
     + Math.min(aggregate.sessionHitCount, 2) * 2
     + Math.min(aggregate.hitCount, 6) * 1.5
-    + recencyBonus;
+    + recencyBonus
+    - (aggregate.titleRestatement ? 20 : 0);
 }
 
 /**
@@ -265,7 +269,9 @@ function countMatchedTerms(haystack: string, terms: string[]): number {
 
 function scorePathLikeCommandSequence(haystack: string, signals: QuerySignals): number {
   if (!signals.isPathLikeCommand || signals.terms.length < 2) return 0;
-  if (containsBoundedPhrase(haystack, signals.normalizedQuery)) return 36;
+  if (containsBoundedPhrase(haystack, signals.normalizedQuery)) {
+    return 36 + scoreTrailingCommandArgs(haystack, signals.normalizedQuery);
+  }
 
   const span = shortestOrderedSpan(tokenize(haystack), signals.terms);
   if (span === null) return 0;
@@ -296,6 +302,42 @@ function shortestOrderedSpan(tokens: string[], terms: string[]): number | null {
   }
 
   return best === Infinity ? null : best;
+}
+
+/**
+ * A title that contains the command plus extra wrapper words ("搜下这个是哪个
+ * 项目路径的") is a search restatement, not evidence of having run the command.
+ * Those titles otherwise collect titlePhrase (+30) and titleTermHits (*10).
+ */
+function titleLooksLikeCommandRestatement(titleLower: string, signals: QuerySignals): boolean {
+  if (!signals.isPathLikeCommand || signals.normalizedQuery.length === 0) return false;
+  if (!containsBoundedPhrase(titleLower, signals.normalizedQuery)) return false;
+  const leftover = titleLower.replaceAll(signals.normalizedQuery, " ");
+  return tokenize(leftover).length >= 2;
+}
+
+/**
+ * Extra path-like or flag-like tokens after a bounded command distinguish an
+ * invocation (`publish fixtures/sample.jsonl --json`) from a question that
+ * merely repeats the command text. Only inspect the same line as this
+ * occurrence so session-level title+summary concat cannot leak a later `cli.js`.
+ */
+function scoreTrailingCommandArgs(haystack: string, phrase: string): number {
+  let offset = 0;
+  while (offset < haystack.length) {
+    const index = haystack.indexOf(phrase, offset);
+    if (index < 0) return 0;
+
+    const before = index > 0 ? haystack[index - 1] : undefined;
+    const afterIndex = index + phrase.length;
+    const after = afterIndex < haystack.length ? haystack[afterIndex] : undefined;
+    if (isPhraseBoundary(before) && isPhraseBoundary(after)) {
+      const window = haystack.slice(afterIndex, afterIndex + 80).split(/\n/)[0] ?? "";
+      if (/[./]/.test(window) || /(?:^|\s)--?[a-z0-9]/.test(window)) return 24;
+    }
+    offset = index + 1;
+  }
+  return 0;
 }
 
 function containsBoundedPhrase(haystack: string, phrase: string): boolean {


### PR DESCRIPTION
## Summary
- Path-like command ranking prefers the session that ran the command over a later title restatement.
- `around_query` keeps the full query window plus a short head; dogfood/skill keep `--query` next to `--seq`.
- Skill: `--sort ended` is not a date filter; short product names need `--cwd`.
- Dogfood runner now passes `find.cwd` as `--cwd` (cross-source), matching the agent CLI.

Rebased onto main after #104 shipped **0.4.3**. This PR is **0.4.4**.

Private dogfood goldens (not in this PR): 5 stale recaptures; eval 16/16 pass.

## Mainline Intent
`int_779c2bbf`. Earlier `int_071015d2` is the same ranking work before rebase — not a real conflict.

## Tested
- `npm run check` — 38 files / 260 tests
- `npm run eval:dogfood` — 16 pass / 0 fail

## Test plan
- [ ] CI green
- [ ] After merge, tag `v0.4.4` and confirm `npm view @act0r/sherlog version`