### PR TITLE
eval: surface returned-context size and public FP/FN mirrors

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,6 +24,7 @@
   - 支持为单个 golden 描述真实检索 workflow：多 query attempt、`sort`、cwd/selector scope、排除 self-hit session
   - 检查 expected session / cwd / matchSource / context key phrase
   - 每个 attempt 会落盘 find/context artifact，scorecard 会标出最终采用的 attempt
+  - scorecard 带 per-case `returnedContext`（chars/bytes）和 batch p50/p95，context 预算回归按 case 可见
   - `hard` 失败会以非零退出阻断本机 gate
   - `candidate` 失败只报告，不阻断
 

--- a/eval/acceptance-gate.test.ts
+++ b/eval/acceptance-gate.test.ts
@@ -5,16 +5,16 @@ describe("acceptance gate", () => {
   test("passes synthetic evidence-level retrieval fixtures", async () => {
     const result = await runAcceptanceGate();
 
-    expect(result.sync.added).toBe(8);
+    expect(result.sync.added).toBe(11);
     expect(result.sourceSyncs["claude-code"].added).toBe(1);
     expect(result.sourceSyncs.pi.added).toBe(1);
     expect(result.scoreboard).toMatchObject({
-      total: 6,
-      pass: 6,
+      total: 8,
+      pass: 8,
       fail: 0,
       hardFail: 0,
       candidateFail: 0,
-      assertionPass: 6,
+      assertionPass: 8,
       assertionFail: 0,
       facetPass: 1,
       facetFail: 0,
@@ -26,9 +26,15 @@ describe("acceptance gate", () => {
       "duplicate-family-diversity",
       "claude-code-message-range-context",
       "pi-session-page-context",
+      "command-restatement-loses-to-execution",
+      "query-window-keeps-table-rows",
     ]);
     expect(result.rows.every((row) => row.predicates.length > 0)).toBe(true);
     expect(result.rows.find((row) => row.id === "message-hit-context")?.facetMark).toBe("pass");
+    expect(result.returnedContext.reads).toBe(6);
+    expect(result.returnedContext.charsP50).toBeGreaterThan(0);
+    expect(result.rows.find((row) => row.id === "query-window-keeps-table-rows")?.returnedContext.read).toBe(true);
+    expect(result.rows.find((row) => row.id === "command-restatement-loses-to-execution")?.returnedContext.read).toBe(false);
   });
 
   test("reports top-result diversity metrics for the duplicate-family case", async () => {

--- a/eval/acceptance-gate.ts
+++ b/eval/acceptance-gate.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildDogfoodScoreboard, desiredContextMode, evaluateDogfoodItem, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
 import type { DogfoodGolden } from "./dogfood-schema";
+import { measureReturnedContext, summarizeReturnedContext, type ReturnedContextMetric, type ReturnedContextSummary } from "./returned-context";
 import { syncSessions } from "../src/indexer";
 import { findSessions, getMessagePage, getMessageRange } from "../src/query";
 import type { FindResult, SyncSummary } from "../src/types";
@@ -21,6 +22,9 @@ const DUP_FAMILY_SESSIONS = [
 const DIVERSE_HIT_SESSION = "66666666-6666-4666-8666-666666666666";
 const CLAUDE_CODE_HIT_SESSION = "claude-code:claude-eval-session";
 const PI_HIT_SESSION = "pi:pi-eval-session";
+const COMMAND_EXEC_SESSION = "77777777-7777-4777-8777-777777777777";
+const COMMAND_RESTATE_SESSION = "88888888-8888-4888-8888-888888888888";
+const QUERY_WINDOW_SESSION = "99999999-9999-4999-8999-999999999999";
 
 type AcceptanceSourceId = "codex" | "claude-code" | "pi";
 
@@ -60,6 +64,7 @@ export interface AcceptanceGateRow {
   failureClasses: DogfoodEvaluation["failureClasses"];
   predicates: DogfoodEvaluation["predicateResults"];
   diversity: TopResultDiversity;
+  returnedContext: ReturnedContextMetric;
 }
 
 export interface AcceptanceGateResult {
@@ -69,6 +74,7 @@ export interface AcceptanceGateResult {
   sync: SyncSummary;
   sourceSyncs: Record<AcceptanceSourceId, SyncSummary>;
   scoreboard: DogfoodScoreboard;
+  returnedContext: ReturnedContextSummary;
   rows: AcceptanceGateRow[];
 }
 
@@ -98,6 +104,7 @@ export async function runAcceptanceGate(options: AcceptanceGateOptions = {}): Pr
       sync: sourceSyncs.codex,
       sourceSyncs,
       scoreboard: buildDogfoodScoreboard(rows.map((row) => ({ status: row.status, evaluation: row }))),
+      returnedContext: summarizeReturnedContext(rows.map((row) => row.returnedContext)),
       rows,
     };
   } finally {
@@ -139,6 +146,7 @@ function evaluateAcceptanceItems(dbPath: string, items: DogfoodGolden[]): Accept
       failureClasses: evaluation.failureClasses,
       predicates: evaluation.predicateResults,
       diversity: topResultDiversity(summary.results, item.expected.topK ?? limit),
+      returnedContext: measureReturnedContext(context),
     };
   });
 }
@@ -164,22 +172,15 @@ function readContextIfNeeded(
   if (!hit) return { unavailableReason: "no selected hit for context read" };
   const context = item.expected.context ?? {};
   if (mode === "read-range") {
-    if (typeof hit.matchSeq !== "number") {
-      // Session-only hit: use the query to locate the real anchor inside the
-      // session transcript, mirroring buildEvidenceReadAction's read-range --query path.
-      const query = context.query ?? item.query;
-      if (!query) {
-        return { kind: "read-range", unavailableReason: "selected hit has no numeric matchSeq and no query available" };
-      }
-      const range = getMessageRange(dbPath, hit.sessionRef, {
-        query,
-        before: context.before ?? 2,
-        after: context.after ?? 2,
-      });
-      return { kind: "read-range", text: messagesText(range.messages) };
+    const query = context.query ?? item.query;
+    if (typeof hit.matchSeq !== "number" && !query) {
+      return { kind: "read-range", unavailableReason: "selected hit has no numeric matchSeq and no query available" };
     }
+    // Keep --seq and --query together so around_query can preserve evidence
+    // the same way evidenceRead.argv / the dogfood runner do.
     const range = getMessageRange(dbPath, hit.sessionRef, {
-      seq: hit.matchSeq,
+      ...(typeof hit.matchSeq === "number" ? { seq: hit.matchSeq } : {}),
+      ...(query ? { query } : {}),
       before: context.before ?? 2,
       after: context.after ?? 2,
     });
@@ -320,6 +321,44 @@ function acceptanceGoldens(roots: AcceptanceFixtureRoots): DogfoodGolden[] {
         },
       },
     },
+    {
+      id: "command-restatement-loses-to-execution",
+      query: "node dist/cli.js publish",
+      intent: "public mirror of the path-like command FP: a later title that restates the command must not beat the session that ran it",
+      status: "hard",
+      expected: {
+        topK: 1,
+        sourceId: "codex",
+        acceptableSessionUuids: [COMMAND_EXEC_SESSION],
+        sessionRef: COMMAND_EXEC_SESSION,
+        cwdContains: "/tmp/sherlog-acceptance/what7",
+        matchSource: "message",
+      },
+    },
+    {
+      id: "query-window-keeps-table-rows",
+      query: "两个格式的关键差异",
+      intent: "public mirror of the elision FN: around_query must keep the full query window so both comparison-table rows stay visible",
+      status: "hard",
+      expected: {
+        topK: 1,
+        sourceId: "codex",
+        acceptableSessionUuids: [QUERY_WINDOW_SESSION],
+        sessionRef: QUERY_WINDOW_SESSION,
+        cwdContains: "/tmp/sherlog-acceptance/format-diff",
+        matchSource: "message",
+        matchSeq: 1,
+        context: {
+          mode: "read-range",
+          before: 0,
+          after: 0,
+          mustContain: [
+            "存储位置 │ ~/.codex/sessions/（扁平）",
+            "对话结构 │ 线性 │ 树形（parentUuid 分支）",
+          ],
+        },
+      },
+    },
   ];
 }
 
@@ -368,6 +407,24 @@ function writeCodexAcceptanceFixtures(root: string): void {
   writeCodexSession(day, DIVERSE_HIT_SESSION, "/tmp/sherlog-acceptance/diverse", [
     event("user_message", "familyneedle staging cutover decision record"),
     event("agent_message", "The distinct session captures the actual cutover decision evidence."),
+  ]);
+  writeCodexSession(day, COMMAND_EXEC_SESSION, "/tmp/sherlog-acceptance/what7", [
+    event("user_message", "怎么使用"),
+    event("agent_message", "cd /tmp/sherlog-acceptance/what7 && node dist/cli.js publish fixtures/sample.jsonl --json"),
+  ]);
+  writeCodexSession(day, COMMAND_RESTATE_SESSION, "/tmp/sherlog-acceptance/play", [
+    event("user_message", "cxs node dist/cli.js publish 搜下这个是哪个项目路径的", "2026-06-27T05:00:00.000Z"),
+    event("agent_message", "这是在搜命令对应的仓库", "2026-06-27T05:00:01.000Z"),
+  ]);
+  writeCodexSession(day, QUERY_WINDOW_SESSION, "/tmp/sherlog-acceptance/format-diff", [
+    event("user_message", "compare the two session transcript formats"),
+    event("agent_message", [
+      "两个格式的关键差异：\n",
+      "存储位置 │ ~/.codex/sessions/（扁平） │ ~/.claude/projects/<hash>/<uuid>.jsonl（嵌套）\n",
+      `${"x".repeat(500)}\n`,
+      "对话结构 │ 线性 │ 树形（parentUuid 分支）\n",
+      "y".repeat(400),
+    ].join("")),
   ]);
 }
 
@@ -424,17 +481,25 @@ function writeCodexSession(day: string, uuid: string, cwd: string, records: Reco
   writeFileSync(filePath, content);
 }
 
-function event(type: "user_message" | "agent_message", message: string): Record<string, unknown> {
-  return line("event_msg", { type, message });
+function event(
+  type: "user_message" | "agent_message",
+  message: string,
+  timestamp = "2026-06-26T05:00:00.000Z",
+): Record<string, unknown> {
+  return line("event_msg", { type, message }, timestamp);
 }
 
 function compacted(message: string): Record<string, unknown> {
   return line("compacted", { message });
 }
 
-function line(type: string, payload: Record<string, unknown>): Record<string, unknown> {
+function line(
+  type: string,
+  payload: Record<string, unknown>,
+  timestamp = "2026-06-26T05:00:00.000Z",
+): Record<string, unknown> {
   return {
-    timestamp: "2026-06-26T05:00:00.000Z",
+    timestamp,
     type,
     payload,
   };

--- a/eval/returned-context.test.ts
+++ b/eval/returned-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { measureReturnedContext, summarizeReturnedContext } from "./returned-context";
+
+describe("returned context metric", () => {
+  test("measures utf8 bytes separately from chars", () => {
+    const metric = measureReturnedContext({ kind: "read-range", text: "回滚预案" });
+    expect(metric).toEqual({
+      read: true,
+      kind: "read-range",
+      chars: 4,
+      bytes: 12,
+    });
+  });
+
+  test("treats a skipped or failed read as unread", () => {
+    expect(measureReturnedContext({ unavailableReason: "no selected hit for context read" })).toEqual({
+      read: false,
+      kind: null,
+      chars: 0,
+      bytes: 0,
+    });
+    expect(measureReturnedContext({})).toEqual({
+      read: false,
+      kind: null,
+      chars: 0,
+      bytes: 0,
+    });
+  });
+
+  test("summarizes only successful reads so scorecards can spot context-budget drift", () => {
+    const summary = summarizeReturnedContext([
+      measureReturnedContext({}),
+      measureReturnedContext({ kind: "read-range", text: "a".repeat(100) }),
+      measureReturnedContext({ kind: "read-range", text: "b".repeat(200) }),
+      measureReturnedContext({ kind: "read-page", text: "c".repeat(400) }),
+    ]);
+    expect(summary).toEqual({
+      reads: 3,
+      charsP50: 200,
+      charsP95: 400,
+      charsMax: 400,
+      bytesMax: 400,
+    });
+  });
+});

--- a/eval/returned-context.ts
+++ b/eval/returned-context.ts
@@ -1,0 +1,49 @@
+export interface ReturnedContextMetric {
+  read: boolean;
+  kind: "read-range" | "read-page" | null;
+  chars: number;
+  bytes: number;
+}
+
+export interface ReturnedContextSummary {
+  reads: number;
+  charsP50: number | null;
+  charsP95: number | null;
+  charsMax: number | null;
+  bytesMax: number | null;
+}
+
+export function measureReturnedContext(input: {
+  text?: string;
+  kind?: "read-range" | "read-page";
+  unavailableReason?: string;
+}): ReturnedContextMetric {
+  if (input.unavailableReason || input.text === undefined) {
+    return { read: false, kind: input.kind ?? null, chars: 0, bytes: 0 };
+  }
+  return {
+    read: true,
+    kind: input.kind ?? null,
+    chars: input.text.length,
+    bytes: Buffer.byteLength(input.text, "utf8"),
+  };
+}
+
+export function summarizeReturnedContext(metrics: ReturnedContextMetric[]): ReturnedContextSummary {
+  const reads = metrics.filter((metric) => metric.read);
+  const chars = reads.map((metric) => metric.chars).sort((left, right) => left - right);
+  const bytes = reads.map((metric) => metric.bytes);
+  return {
+    reads: reads.length,
+    charsP50: percentile(chars, 0.5),
+    charsP95: percentile(chars, 0.95),
+    charsMax: chars.length > 0 ? chars[chars.length - 1]! : null,
+    bytesMax: bytes.length > 0 ? Math.max(...bytes) : null,
+  };
+}
+
+function percentile(sorted: number[], fraction: number): number | null {
+  if (sorted.length === 0) return null;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * fraction) - 1));
+  return sorted[index]!;
+}

--- a/eval/run-dogfood-eval.ts
+++ b/eval/run-dogfood-eval.ts
@@ -4,6 +4,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn as childSpawn } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { buildDogfoodScoreboard, buildFindCliArgs, buildReadRangeContextArgs, desiredContextMode, evaluateDogfoodItem, missingContextNeedles, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
+import { measureReturnedContext, summarizeReturnedContext, type ReturnedContextMetric, type ReturnedContextSummary } from "./returned-context";
 import { parseDogfoodJsonl, type DogfoodGolden } from "./dogfood-schema";
 import type { FindResult, FindSort, Selector } from "../src/types";
 
@@ -50,6 +51,7 @@ interface DogfoodEvalRow {
   selectedTitle: string;
   findJsonPath: string;
   contextTxtPath?: string;
+  returnedContext: ReturnedContextMetric;
   attemptCount: number;
   selectedAttemptOrdinal: number | null;
   selectedAttemptQuery: string;
@@ -64,6 +66,7 @@ interface DogfoodAttemptRow {
   findJsonPath: string;
   findTxtPath: string;
   contextTxtPath?: string;
+  returnedContext: ReturnedContextMetric;
 }
 
 const rows: DogfoodEvalRow[] = [];
@@ -81,6 +84,7 @@ for (const [index, item] of entries.entries()) {
     selectedTitle: selectedAttempt?.selectedTitle ?? "(none)",
     findJsonPath: selectedAttempt?.findJsonPath ?? "",
     contextTxtPath: selectedAttempt?.contextTxtPath,
+    returnedContext: selectedAttempt?.returnedContext ?? measureReturnedContext({}),
     attemptCount: attempts.length,
     selectedAttemptOrdinal: selectedAttempt?.spec.ordinal ?? null,
     selectedAttemptQuery: selectedAttempt?.spec.query ?? item.query,
@@ -89,12 +93,13 @@ for (const [index, item] of entries.entries()) {
 }
 
 const scoreboard = buildDogfoodScoreboard(rows.map((row) => ({ status: row.item.status, evaluation: row.evaluation })));
+const returnedContext = summarizeReturnedContext(rows.map((row) => row.returnedContext));
 const readmePath = join(outDir, "README.md");
 const scorecardPath = join(outDir, "scorecard.json");
-writeFileSync(readmePath, renderReadme(args.goldenPath, scoreboard, rows));
-writeFileSync(scorecardPath, `${JSON.stringify({ source: args.goldenPath, scoreboard, rows }, null, 2)}\n`);
+writeFileSync(readmePath, renderReadme(args.goldenPath, scoreboard, returnedContext, rows));
+writeFileSync(scorecardPath, `${JSON.stringify({ source: args.goldenPath, scoreboard, returnedContext, rows }, null, 2)}\n`);
 
-console.log(JSON.stringify({ outDir, readme: readmePath, scorecard: scorecardPath, scoreboard }, null, 2));
+console.log(JSON.stringify({ outDir, readme: readmePath, scorecard: scorecardPath, scoreboard, returnedContext }, null, 2));
 if (scoreboard.hardFail > 0) process.exitCode = 1;
 
 async function runFindAttempts(
@@ -135,6 +140,7 @@ async function runFindAttempts(
       findJsonPath,
       findTxtPath,
       contextTxtPath: context.textPath,
+      returnedContext: measureReturnedContext(context),
     });
   }
 
@@ -257,6 +263,7 @@ function buildContextCommand(
 function renderReadme(
   sourcePath: string,
   scoreboard: DogfoodScoreboard,
+  returnedContext: ReturnedContextSummary,
   rows: DogfoodEvalRow[],
 ): string {
   const lines = [
@@ -278,13 +285,17 @@ function renderReadme(
     `- assertion_fail: ${scoreboard.assertionFail}`,
     `- facet_pass: ${scoreboard.facetPass}`,
     `- facet_fail: ${scoreboard.facetFail}`,
+    `- context_reads: ${returnedContext.reads}`,
+    `- context_chars_p50: ${returnedContext.charsP50 ?? "-"}`,
+    `- context_chars_p95: ${returnedContext.charsP95 ?? "-"}`,
+    `- context_chars_max: ${returnedContext.charsMax ?? "-"}`,
     "",
-    "| id | status | mark | assertions | facets | failure_classes | blocking | selected_rank | selected_title |",
-    "|----|--------|------|------------|--------|-----------------|----------|---------------|----------------|",
+    "| id | status | mark | assertions | facets | failure_classes | blocking | selected_rank | context_chars | selected_title |",
+    "|----|--------|------|------------|--------|-----------------|----------|---------------|---------------|----------------|",
   ];
 
   for (const row of rows) {
-    lines.push(`| ${row.item.id} | ${row.item.status} | ${row.evaluation.mark} | ${row.evaluation.assertionMark} | ${row.evaluation.facetMark} | ${formatFailureClasses(row.evaluation.failureClasses)} | ${row.evaluation.blocking} | ${row.evaluation.selected.rank ?? "-"} | ${row.selectedTitle.replaceAll("|", "¦").slice(0, 60)} |`);
+    lines.push(`| ${row.item.id} | ${row.item.status} | ${row.evaluation.mark} | ${row.evaluation.assertionMark} | ${row.evaluation.facetMark} | ${formatFailureClasses(row.evaluation.failureClasses)} | ${row.evaluation.blocking} | ${row.evaluation.selected.rank ?? "-"} | ${row.returnedContext.read ? row.returnedContext.chars : "-"} | ${row.selectedTitle.replaceAll("|", "¦").slice(0, 60)} |`);
   }
 
   for (const row of rows) {
@@ -302,6 +313,7 @@ function renderReadme(
     lines.push(`- selected_title: ${row.selectedTitle}`);
     lines.push(`- find_json: \`${rel(row.findJsonPath)}\``);
     if (row.contextTxtPath) lines.push(`- context_txt: \`${rel(row.contextTxtPath)}\``);
+    lines.push(`- returned_context: ${row.returnedContext.read ? `${row.returnedContext.kind} ${row.returnedContext.chars} chars / ${row.returnedContext.bytes} bytes` : "not read"}`);
     lines.push(`- predicates: ${formatPredicates(row.evaluation.predicateResults)}`);
     if (row.attempts.length > 1) {
       lines.push("", "### attempts", "");


### PR DESCRIPTION
## Summary
- Dogfood and acceptance scorecards now record per-case `returnedContext` (chars/bytes) plus batch p50/p95, so context-budget regressions are visible without `eval:perf`.
- Acceptance gate adds public synthetic mirrors of the #101 item-1 failure shapes: executed path-like command vs later title restatement, and `around_query` keeping both comparison-table rows.
- Acceptance `read-range` keeps `--seq` and `--query` together, matching the dogfood runner / `evidenceRead.argv`.

Closes #101.

## Test plan
- [x] `npm run check` (265 tests)
- [ ] CI green


Made with [Cursor](https://cursor.com)