### PR TITLE
refactor: single-branch query surface; v7 becomes migration-only import format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - v8 writer 固定使用 rollback `journal_mode=DELETE` 与 `synchronous=FULL`。这是短命 CLI + 显式 single-writer 的有意识取舍：发布态 index 保持单文件，所有只读命令在 DB `0444`、目录 `0555` 时也不会创建 `-wal` / `-shm`；不要改成 `immutable=1` 或 close-time WAL seal，它们在并发 writer/reader 下会读旧数据或留下转换竞态。
 - `sessions` view 故意没有 `INSTEAD OF` trigger：高级只读 SQL 保持兼容，旧 TypeScript writer 对 v8 写入时会 fail closed。
 - 检索主链是 `SQLite candidate recall -> deterministic session ranking -> evidenceRead -> read-range/read-page`。真实 message 与 session profile 是两类 document；profile 命中不得伪装成 message evidence。`read-range --query` 无 message anchor 返回 typed `anchor_not_found`（含 `matchedProfileFields` 与闭包 read-page nextAction），不回退 seq 0；read payload 的 session 记录含 `compactText`/`reasoningSummaryText`。
+- 查询面单分支：find/read/list 等内容命令只讲 v8；legacy v7 是 import 格式。v7 库上内容命令返回 typed `index_schema_upgrade_required` + nextAction `shlog sync`；`status` 正常工作并报告 `index.layout: legacy_v7`（升级 nudge）。迁移只发生在显式 writer 命令，副作用是 coverage 清空（需重新 sync 各 root）、保留 `*.v7.bak.*` 备份、legacy cold-roots.json tombstone、旧 TS writer fail-closed。
 - `find` 的 `evidenceRead.command` 是 `executable:"inherit"` + 闭包 `--source/--db/--json` 的 `args` + `sideEffect:"read_index"`，custom DB 下原样执行必须读回原 candidate。无 `--root/--cwd/--selector` 的 find 解析为各 source 的 canonical default `all(root)`，recall/coverage/scanned 三 scope 一致。
 - v8 tokenizer 使用 UAX #29 lowercase word 与重叠 CJK Unicode-scalar bigram。FTS column 权重为 body 1.0、title 8.0、summary 3.0、compact 4.0、reasoning summary 1.2。
 - `source` / root / cwd / date / session / exclude 约束尽量在 SQL candidate generation 阶段下推，不先召回大集合再在 app 层过滤。
@@ -30,7 +31,7 @@
 - strict sync 遇到选中输入错误时不发布部分 coverage；`--best-effort` 可提交成功文件，但不会伪造 complete coverage。`--prune` 只删除 hot 与 registered cold 都不存在的同 source 投影。
 - v8 `cold_roots` 表是 cold registration 真相。legacy `cold-roots.json` 只作为首次 v7/v8 cutover 的一次性导入输入；导入后使用 tombstone 阻止旧 writer 复活配置。
 - v7 -> v8 migration 只发生在授权 writer 路径，采用 copy/verify/backup/atomic publish；read-only commands 不迁移。cold-only projection 必须保留。
-- 当前 native release pipeline 仅声明 `aarch64-apple-darwin`、`x86_64-apple-darwin`、`x86_64-unknown-linux-gnu`。源码与 pipeline 已 ready，但本次 cutover 尚未发布 native tag/assets；本机全局 `shlog --version` 当前实测仍为旧发布版 `0.4.4`，发布/重装后必须重新核对路径与版本。
+- native release pipeline 声明 `aarch64-apple-darwin`、`x86_64-apple-darwin`、`x86_64-unknown-linux-gnu` 三个目标。v0.5.0 已发布 tag/assets 并完成本机安装验证；后续版本走同一 tag → release workflow → 回读 assets/attestations → installer 重装流程。
 
 不要把下面这些说成已完成：
 
@@ -41,7 +42,6 @@
 - 完整的 incremental/full-replay property/state-machine test 矩阵；当前只有聚焦 transition/migration tests
 - candidate/filter/exact 各阶段完整可观测性与 `weakMatch`/`matchMode` 公共 contract
 - 全正文 typo-tolerant fuzzy、evidence-read frecency
-- native GitHub release/tag/assets 已发布或本机 global CLI 已切换为 native
 - Linux arm64、musl 或 Windows native archive
 - watcher / daemon、LMDB 或第二状态真相源
 
@@ -53,7 +53,7 @@
 - [runner.rs](rust/src/runner.rs): parse/dispatch/error routing
 - [sources/](rust/src/sources): source adapters, inventory and privacy projection
 - [sync/](rust/src/sync): lock, scan/project/stage, append/full transitions, cold retention and publish
-- [index/](rust/src/index): v7 read compatibility, v8 reader/writer/schema/SQL invariants
+- [index/](rust/src/index): v8 reader/writer/schema/SQL invariants；v7 仅作为 migration 的 import 格式（内容命令 fail-closed）
 - [retrieval/](rust/src/retrieval): query analysis, candidate aggregation, ranking, snippets and evidence-read plans
 - [migration/](rust/src/migration): v7 -> v8 copy/verify/atomic publication
 - [selector.rs](rust/src/selector.rs), [coverage.rs](rust/src/coverage.rs), [tokenizer.rs](rust/src/tokenizer.rs): shared invariants

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "sherlog-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/docs/RUST_ARCHITECTURE.md
+++ b/docs/RUST_ARCHITECTURE.md
@@ -179,7 +179,7 @@ coverage 与 content projection 分离：
 
 - sync 只有在 snapshot proof 完整时写 complete record；
 - best-effort errors 不产生虚假 complete coverage；
-- find/list/read/stats 只看 stored index proof；
+- find/list/read/stats 只讲 v8 并只看 stored index proof；v7 库上内容命令 fail-closed 返回 typed `index_schema_upgrade_required`（nextAction 为显式 `shlog sync`），只有 migration 把 v7 当 import 格式消费；
 - 无 `--root/--cwd/--selector` 的 find 解析为各 source 的 canonical default `all(root)`，recall scope == scanned count scope == coverage scope；
 - status 不返回/检索正文、不写 index；inventory cache miss 可流式读取 raw，但仅以 privacy-allowlisted accepted projection 派生 live proof，exact `mtime_ns`/checkpoint cache hit 不重 parse；同 file-set 的 `source_content_changed` 会用持久化 `boundary_digest` 前缀证明区分 proven append（继续 advisory query）与 truncate/prefix/same-size rewrite（`recommendedAction: sync`）；
 - `--prune` 遇 registered cold root missing/unmount/permission 时 fail closed，绝不把不可达当作空集删除 cold-only projection；

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -72,6 +72,10 @@ shlog find "X" --cwd /Users/you/work/project --sort ended \
 
 不要只凭 title/snippet 回答内容问题。优先原样执行 JSON 结果的 `evidenceRead.command`（`executable:"inherit"` + `args`，已闭包 `--db/--json`）；message 太长且关键内容被省略时，在同一 read 命令上加 `--max-message-chars 0`。`read-range --query` 无 message anchor 时返回 typed `anchor_not_found`，按 nextAction 回退 `read-page`，不要伪造 seq 0。
 
+## 从 0.4.x 升级（一次性迁移）
+
+0.4.x 的 v7 index 是 legacy import 格式：`status` 会报告 `index.layout: legacy_v7`，内容命令（find/read/list）会返回 typed `index_schema_upgrade_required`，`nextAction` 指向一次显式 `shlog sync`。执行一次 sync 即完成迁移与 coverage 重建；迁移保留 `*.v7.bak.*` 备份、legacy cold-roots.json 被 tombstone、旧 0.4.4 writer 对 v8 fail-closed。没有自动升级命令；版本升级由 installer/brew/npm 等分发层完成。
+
 ## Source
 
 公开值：

--- a/eval/contract-gate.ts
+++ b/eval/contract-gate.ts
@@ -42,6 +42,7 @@ const OPAQUE_EPOCH_JSON_FIELDS = new Map<string, string>([
   ["sourceFileSetFingerprint", "<SOURCE_FILE_SET_FINGERPRINT>"],
   ["currentSourceFileSetFingerprint", "<SOURCE_FILE_SET_FINGERPRINT>"],
   ["score", "<RANK_SCORE>"],
+  ["layout", "<INDEX_LAYOUT>"],
 ]);
 
 export interface ContractGateOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sherlog-development",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sherlog-development",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sherlog-development",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Development and differential-evaluation workspace for the native Sherlog CLI",

--- a/rust/src/app/mod.rs
+++ b/rust/src/app/mod.rs
@@ -125,7 +125,7 @@ impl NativeAppServices {
             };
             let excluded_session_uuids =
                 self.resolve_excluded_session_uuids(reader, source, &excluded_sessions)?;
-            let candidates = recall_with_fallback(
+            let candidates = self.recall_with_fallback(
                 reader,
                 &args.query,
                 RecallSpec {
@@ -241,7 +241,7 @@ impl NativeAppServices {
         let top_hit = if explicit_seq.is_none() && query.is_some_and(|value| !value.is_empty()) {
             let analysis = analyze_query(query.expect("query checked above"));
             let like_needle = recall_like_needle(&analysis.recall);
-            let mut candidates = recall_with_fallback(
+            let mut candidates = self.recall_with_fallback(
                 reader,
                 query.expect("query checked above"),
                 RecallSpec {
@@ -545,6 +545,37 @@ impl NativeAppServices {
             }
         }
     }
+    fn recall_with_fallback(
+        &self,
+        reader: &IndexReader,
+        query: &str,
+        spec: RecallSpec,
+    ) -> Result<Vec<CandidateEvidence>, AppError> {
+        let recall = |terms: Vec<String>, like_needle: Option<String>| {
+            let mut request = spec.clone();
+            request.terms = terms;
+            request.like_needle = like_needle;
+            reader.recall(&request)
+        };
+        let map = |error: IndexError| map_index_error(error, reader.path(), &self.cwd, &self.paths);
+        let mut candidates = recall(spec.terms.clone(), spec.like_needle.clone()).map_err(map)?;
+        if !candidates.is_empty() {
+            return Ok(candidates);
+        }
+        let mut seen = HashSet::new();
+        for relaxed in build_relaxed_recall_queries(query) {
+            let analysis = analyze_query(&relaxed);
+            for candidate in recall(analysis.terms, recall_like_needle(&analysis.recall))
+                .map_err(|error| AppError::output(format!("query index: {error}")))?
+            {
+                let key = candidate_key(&candidate);
+                if seen.insert(key) {
+                    candidates.push(candidate);
+                }
+            }
+        }
+        Ok(candidates)
+    }
 }
 
 impl AppServices for NativeAppServices {
@@ -792,37 +823,6 @@ impl AppServices for NativeAppServices {
             write_stats_text(stdout, &summary)
         }
     }
-}
-
-fn recall_with_fallback(
-    reader: &IndexReader,
-    query: &str,
-    spec: RecallSpec,
-) -> Result<Vec<CandidateEvidence>, AppError> {
-    let recall = |terms: Vec<String>, like_needle: Option<String>| {
-        let mut request = spec.clone();
-        request.terms = terms;
-        request.like_needle = like_needle;
-        reader.recall(&request)
-    };
-    let mut candidates = recall(spec.terms.clone(), spec.like_needle.clone())
-        .map_err(|error| AppError::output(format!("query index: {error}")))?;
-    if !candidates.is_empty() {
-        return Ok(candidates);
-    }
-    let mut seen = HashSet::new();
-    for relaxed in build_relaxed_recall_queries(query) {
-        let analysis = analyze_query(&relaxed);
-        for candidate in recall(analysis.terms, recall_like_needle(&analysis.recall))
-            .map_err(|error| AppError::output(format!("query index: {error}")))?
-        {
-            let key = candidate_key(&candidate);
-            if seen.insert(key) {
-                candidates.push(candidate);
-            }
-        }
-    }
-    Ok(candidates)
 }
 
 fn recall_like_needle(mode: &RecallMode) -> Option<String> {

--- a/rust/src/app/status.rs
+++ b/rust/src/app/status.rs
@@ -59,6 +59,10 @@ pub(super) fn collect_status(
             (
                 StatusIndex {
                     exists: true,
+                    layout: match reader.layout() {
+                        IndexLayout::V8 => "native_v8".to_owned(),
+                        IndexLayout::V7 => "legacy_v7".to_owned(),
+                    },
                     session_count: stats.session_count,
                     message_count: stats.message_count,
                     earliest_started_at: stats.earliest_started_at,
@@ -289,6 +293,7 @@ fn scan_cached<'a>(
 fn empty_index_status() -> StatusIndex {
     StatusIndex {
         exists: false,
+        layout: "none".to_owned(),
         session_count: 0,
         message_count: 0,
         earliest_started_at: None,

--- a/rust/src/app/tests.rs
+++ b/rust/src/app/tests.rs
@@ -919,6 +919,107 @@ fn first_sync_rejects_malformed_legacy_cold_state_without_publishing_v8() {
 }
 
 #[test]
+fn legacy_v7_content_commands_fail_closed_and_status_reports_the_layout() {
+    let directory = TempDir::new().unwrap();
+    let root = directory.path().join("sessions");
+    let id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    let raw = root
+        .join("2026/08/15")
+        .join(format!("rollout-2026-08-15T00-00-00-{id}.jsonl"));
+    write_codex_session(&raw, id, &[("user_message", "legacy evidence")]);
+    let paths = resolved_paths(&directory, &root);
+    std::fs::create_dir_all(&paths.data_dir).unwrap();
+    create_v7_index(&paths.db_path, &raw, id, &root);
+    let mut services = NativeAppServices::new(paths.clone(), directory.path().to_path_buf());
+
+    // status is the nudge surface: it works and names the legacy layout.
+    let status = json_output(|stdout, stderr| {
+        services.status(
+            &StatusArgs {
+                source: Some("codex".to_owned()),
+                root: Some(root.clone()),
+                selector: None,
+                cwd: None,
+                database: DatabaseArg {
+                    db: paths.db_path.clone(),
+                },
+                inventory: false,
+                json: true,
+            },
+            stdout,
+            stderr,
+        )
+    });
+    assert_eq!(status["index"]["layout"], serde_json::json!("legacy_v7"));
+    assert_eq!(status["index"]["exists"], serde_json::json!(true));
+
+    // Content-bearing commands fail closed with the typed upgrade error.
+    let (code, stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "find".to_owned(),
+            "legacy".to_owned(),
+            "--db".to_owned(),
+            paths.db_path.to_string_lossy().into_owned(),
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 1);
+    assert!(stderr.is_empty());
+    let payload: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(
+        payload["error"]["code"],
+        serde_json::json!("index_schema_upgrade_required")
+    );
+    assert_eq!(
+        payload["error"]["nextAction"]["commands"][0]["argv"],
+        serde_json::json!([
+            "shlog",
+            "sync",
+            "--db",
+            paths.db_path.to_string_lossy(),
+            "--json"
+        ])
+    );
+
+    // One explicit sync migrates and restores normal reads.
+    let (code, _stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "sync".to_owned(),
+            "--db".to_owned(),
+            paths.db_path.to_string_lossy().into_owned(),
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let found = json_output(|stdout, stderr| {
+        services.find(
+            &FindArgs {
+                query: "legacy evidence".to_owned(),
+                source: Some("codex".to_owned()),
+                limit: 10,
+                root: None,
+                selector: None,
+                cwd: None,
+                sort: CliFindSort::Relevance,
+                exclude_session: vec![],
+                database: DatabaseArg {
+                    db: paths.db_path.clone(),
+                },
+                json: true,
+            },
+            stdout,
+            stderr,
+        )
+    });
+    assert_eq!(found["results"][0]["sessionRef"], serde_json::json!(id));
+}
+
+#[test]
 fn explicit_sync_migrates_v7_before_running_the_v8_writer() {
     let directory = TempDir::new().unwrap();
     let root = directory.path().join("sessions");

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -296,6 +296,17 @@ impl AppError {
                 "dbPath": db_path,
                 "missingColumns": missing_columns,
                 "hint": "A supported v7 index is migrated only by an explicit scoped `shlog sync`. For a newer or incompatible v8 version/epoch, use a compatible `shlog` binary or restore a trusted backup; repeated sync will not make it compatible.",
+                "nextAction": {
+                    "kind": "migrate_legacy_index",
+                    "reason": "index_schema_upgrade_required",
+                    "commands": [
+                        {
+                            "label": "migrate legacy index with sync",
+                            "recommended": true,
+                            "argv": ["shlog", "sync", "--db", db_path, "--json"],
+                        }
+                    ]
+                }
             }),
             Self::SessionNotFound {
                 session_ref,

--- a/rust/src/index/reader.rs
+++ b/rust/src/index/reader.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -115,6 +114,7 @@ impl IndexReader {
     }
 
     pub fn list(&self, query: &SessionListQuery) -> IndexResult<Vec<SessionListEntry>> {
+        self.require_v8("list")?;
         let mut conditions = Vec::new();
         let mut values = Vec::new();
         if let Some(selector) = &query.selector {
@@ -163,6 +163,7 @@ impl IndexReader {
     }
 
     pub fn load_session(&self, session_ref: &SessionRef) -> IndexResult<Option<SessionRecord>> {
+        self.require_v8("load session")?;
         Ok(self
             .load_stored_session(session_ref)?
             .map(|session| public_session(&session)))
@@ -174,6 +175,7 @@ impl IndexReader {
         offset: u64,
         limit: u64,
     ) -> IndexResult<ReadPageSummary> {
+        self.require_v8("read-page")?;
         let session = self.require_stored_session(session_ref)?;
         let messages = self.messages_for_page(
             session.id,
@@ -203,6 +205,7 @@ impl IndexReader {
         before: u64,
         after: u64,
     ) -> IndexResult<ReadRangeSummary> {
+        self.require_v8("read-range")?;
         let session = self.require_stored_session(session_ref)?;
         let before = i64::try_from(before).unwrap_or(i64::MAX);
         let after = i64::try_from(after).unwrap_or(i64::MAX);
@@ -398,27 +401,21 @@ impl IndexReader {
                 "recall session source must be present in RecallSpec.sources".to_owned(),
             ));
         }
+        self.require_v8("recall")?;
         match (self.layout, like_needle) {
             (IndexLayout::V8, Some(needle)) => self.recall_v8_like(spec, needle),
-            (IndexLayout::V7, Some(needle)) => self.recall_v7_like(spec, needle),
             (IndexLayout::V8, None) => self.recall_v8(spec),
-            (IndexLayout::V7, None) => self.recall_v7(spec),
+            (IndexLayout::V7, _) => unreachable!("recall is gated to v8 above"),
         }
     }
 
     /// Export only stored projection. No raw transcript is consulted, so this
     /// remains usable for cold-only sessions during copy migration.
     pub fn export_session_bundle(&self, session_ref: &SessionRef) -> IndexResult<SessionBundle> {
+        self.require_v8("export session bundle")?;
         let session = self.require_stored_session(session_ref)?;
-        let documents = match self.layout {
-            IndexLayout::V8 => self.load_v8_documents(session.id)?,
-            IndexLayout::V7 => self.load_v7_documents(&session)?,
-        };
-        let source_files = if self.layout == IndexLayout::V8 {
-            self.source_files_for_session(&session)?
-        } else {
-            Vec::new()
-        };
+        let documents = self.load_v8_documents(session.id)?;
+        let source_files = self.source_files_for_session(&session)?;
         Ok(SessionBundle {
             session,
             documents,
@@ -427,10 +424,8 @@ impl IndexReader {
     }
 
     pub fn check_invariants(&self) -> IndexResult<InvariantReport> {
-        match self.layout {
-            IndexLayout::V8 => inspect_v8_invariants(&self.connection),
-            IndexLayout::V7 => inspect_v7_invariants(&self.connection),
-        }
+        self.require_v8("check invariants")?;
+        inspect_v8_invariants(&self.connection)
     }
 
     pub fn ensure_invariants(&self) -> IndexResult<InvariantReport> {
@@ -443,21 +438,15 @@ impl IndexReader {
     }
 
     fn load_stored_session(&self, session_ref: &SessionRef) -> IndexResult<Option<StoredSession>> {
-        let document_count = if self.layout == IndexLayout::V8 {
-            "document_count"
-        } else {
-            "message_count + 1"
-        };
-        let sql = format!(
-            "SELECT id, source_id, native_session_id, session_key, session_uuid, file_path, \
+        self.require_v8("load session")?;
+        let sql = "SELECT id, source_id, native_session_id, session_key, session_uuid, file_path, \
              source_root, title, summary_text, compact_text, reasoning_summary_text, cwd, model, \
-             started_at, ended_at, path_date, message_count, {document_count}, raw_file_mtime, \
+             started_at, ended_at, path_date, message_count, document_count, raw_file_mtime, \
              raw_file_size, index_version, updated_at FROM sessions \
-             WHERE source_id=? AND native_session_id=? LIMIT 1"
-        );
+             WHERE source_id=? AND native_session_id=? LIMIT 1";
         self.connection
             .query_row(
-                &sql,
+                sql,
                 params![
                     session_ref.source_id.as_str(),
                     session_ref.native_session_id
@@ -479,17 +468,9 @@ impl IndexReader {
         offset: i64,
         limit: i64,
     ) -> IndexResult<Vec<MessageRecord>> {
-        let sql = match self.layout {
-            IndexLayout::V8 => {
-                "SELECT s.session_uuid, d.seq, d.role, d.body_text, d.timestamp, d.source_kind \
+        let sql = "SELECT s.session_uuid, d.seq, d.role, d.body_text, d.timestamp, d.source_kind \
                  FROM documents d JOIN sessions s ON s.id=d.session_id \
-                 WHERE d.session_id=? AND d.kind='message' ORDER BY d.seq LIMIT ? OFFSET ?"
-            }
-            IndexLayout::V7 => {
-                "SELECT session_uuid, seq, role, content_text, timestamp, source_kind \
-                 FROM messages WHERE session_id=? ORDER BY seq LIMIT ? OFFSET ?"
-            }
-        };
+                 WHERE d.session_id=? AND d.kind='message' ORDER BY d.seq LIMIT ? OFFSET ?";
         let mut statement = self.connection.prepare(sql)?;
         let messages = statement
             .query_map(params![session_id, limit, offset], message_from_row)?
@@ -503,17 +484,9 @@ impl IndexReader {
         start: i64,
         end: i64,
     ) -> IndexResult<Vec<MessageRecord>> {
-        let sql = match self.layout {
-            IndexLayout::V8 => {
-                "SELECT s.session_uuid, d.seq, d.role, d.body_text, d.timestamp, d.source_kind \
+        let sql = "SELECT s.session_uuid, d.seq, d.role, d.body_text, d.timestamp, d.source_kind \
                  FROM documents d JOIN sessions s ON s.id=d.session_id \
-                 WHERE d.session_id=? AND d.kind='message' AND d.seq BETWEEN ? AND ? ORDER BY d.seq"
-            }
-            IndexLayout::V7 => {
-                "SELECT session_uuid, seq, role, content_text, timestamp, source_kind \
-                 FROM messages WHERE session_id=? AND seq BETWEEN ? AND ? ORDER BY seq"
-            }
-        };
+                 WHERE d.session_id=? AND d.kind='message' AND d.seq BETWEEN ? AND ? ORDER BY d.seq";
         let mut statement = self.connection.prepare(sql)?;
         let messages = statement
             .query_map(params![session_id, start, end], message_from_row)?
@@ -567,15 +540,7 @@ impl IndexReader {
     }
 
     fn coverage_version_is_current(&self, index_version: &str) -> bool {
-        match self.layout {
-            IndexLayout::V8 => {
-                self.metadata.coverage_epoch == COVERAGE_EPOCH && index_version == INDEX_VERSION
-            }
-            IndexLayout::V7 => matches!(
-                index_version,
-                "shlog-v7-source-identity" | "cxs-v7-source-identity"
-            ),
-        }
+        self.metadata.coverage_epoch == COVERAGE_EPOCH && index_version == INDEX_VERSION
     }
 
     fn recall_v8(&self, spec: &RecallSpec) -> IndexResult<Vec<CandidateEvidence>> {
@@ -636,138 +601,6 @@ impl IndexReader {
         Ok(candidates)
     }
 
-    fn recall_v7(&self, spec: &RecallSpec) -> IndexResult<Vec<CandidateEvidence>> {
-        let mut candidates = Vec::new();
-        if table_exists(&self.connection, "messages_fts")? {
-            candidates.extend(self.recall_v7_messages(spec)?);
-        }
-        if table_exists(&self.connection, "sessions_fts")? {
-            candidates.extend(self.recall_v7_profiles(spec)?);
-        }
-        sort_candidates(&mut candidates, spec.order);
-        candidates.truncate(spec.limit);
-        Ok(candidates)
-    }
-
-    fn recall_v7_like(
-        &self,
-        spec: &RecallSpec,
-        needle: &str,
-    ) -> IndexResult<Vec<CandidateEvidence>> {
-        let mut candidates = self.recall_v7_messages_like(spec, needle)?;
-        candidates.extend(self.recall_v7_profiles_like(spec, needle)?);
-        sort_candidates(&mut candidates, spec.order);
-        candidates.truncate(spec.limit);
-        Ok(candidates)
-    }
-
-    fn recall_v7_messages(&self, spec: &RecallSpec) -> IndexResult<Vec<CandidateEvidence>> {
-        let mut conditions = vec!["messages_fts MATCH ?".to_owned()];
-        let mut values = vec![fts_match(&spec.terms).into()];
-        add_recall_scope(&mut conditions, &mut values, spec, "s")?;
-        values.push(to_i64(spec.limit as u64, "recall limit")?.into());
-        let order = recall_order_sql(spec.order, "score", "s", Some("m"));
-        let sql = format!(
-            "SELECT m.id, s.id, s.source_id, s.session_key, s.session_uuid, s.title, \
-             s.summary_text, s.compact_text, s.reasoning_summary_text, s.cwd, s.started_at, \
-             s.ended_at, s.message_count, 'message', m.seq, m.role, m.timestamp, m.content_text, \
-             NULL, NULL, bm25(messages_fts) AS score \
-             FROM messages_fts JOIN messages m ON m.id=messages_fts.rowid \
-             JOIN sessions s ON s.id=m.session_id \
-             WHERE {} ORDER BY {order} LIMIT ?",
-            conditions.join(" AND ")
-        );
-        let mut statement = self.connection.prepare(&sql)?;
-        let candidates = statement
-            .query_map(params_from_iter(values), candidate_v8_from_row)?
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(candidates)
-    }
-
-    fn recall_v7_messages_like(
-        &self,
-        spec: &RecallSpec,
-        needle: &str,
-    ) -> IndexResult<Vec<CandidateEvidence>> {
-        let pattern = format!("%{}%", escape_like(needle));
-        let mut conditions = vec!["m.content_text LIKE ? ESCAPE '\\'".to_owned()];
-        let mut values = vec![sql_text(&pattern)];
-        add_recall_scope(&mut conditions, &mut values, spec, "s")?;
-        values.push(to_i64(spec.limit as u64, "recall limit")?.into());
-        let order = recall_order_sql(spec.order, "score", "s", Some("m"));
-        let sql = format!(
-            "SELECT m.id, s.id, s.source_id, s.session_key, s.session_uuid, s.title, \
-             s.summary_text, s.compact_text, s.reasoning_summary_text, s.cwd, s.started_at, \
-             s.ended_at, s.message_count, 'message', m.seq, m.role, m.timestamp, m.content_text, \
-             NULL, NULL, 0.0 AS score \
-             FROM messages m JOIN sessions s ON s.id=m.session_id \
-             WHERE {} ORDER BY {order} LIMIT ?",
-            conditions.join(" AND ")
-        );
-        let mut statement = self.connection.prepare(&sql)?;
-        let candidates = statement
-            .query_map(params_from_iter(values), candidate_v8_from_row)?
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(candidates)
-    }
-
-    fn recall_v7_profiles(&self, spec: &RecallSpec) -> IndexResult<Vec<CandidateEvidence>> {
-        let mut conditions = vec!["sessions_fts MATCH ?".to_owned()];
-        let mut values = vec![fts_match(&spec.terms).into()];
-        add_recall_scope(&mut conditions, &mut values, spec, "s")?;
-        values.push(to_i64(spec.limit as u64, "recall limit")?.into());
-        let order = recall_order_sql(spec.order, "score", "s", None);
-        let sql = format!(
-            "SELECT NULL, s.id, s.source_id, s.session_key, s.session_uuid, s.title, \
-             s.summary_text, s.compact_text, s.reasoning_summary_text, s.cwd, s.started_at, \
-             s.ended_at, s.message_count, 'session_profile', NULL, NULL, NULL, '', NULL, NULL, \
-             bm25(sessions_fts, 8.0, 3.0, 4.0, 1.2) AS score \
-             FROM sessions_fts JOIN sessions s ON s.id=sessions_fts.rowid \
-             WHERE {} ORDER BY {order} LIMIT ?",
-            conditions.join(" AND ")
-        );
-        let mut statement = self.connection.prepare(&sql)?;
-        let candidates = statement
-            .query_map(params_from_iter(values), candidate_v8_from_row)?
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(candidates)
-    }
-
-    fn recall_v7_profiles_like(
-        &self,
-        spec: &RecallSpec,
-        needle: &str,
-    ) -> IndexResult<Vec<CandidateEvidence>> {
-        let pattern = format!("%{}%", escape_like(needle));
-        let mut conditions = vec![
-            "(s.title LIKE ? ESCAPE '\\' OR s.summary_text LIKE ? ESCAPE '\\' OR \
-             s.compact_text LIKE ? ESCAPE '\\' OR s.reasoning_summary_text LIKE ? ESCAPE '\\')"
-                .to_owned(),
-        ];
-        let mut values = (0..4)
-            .map(|_| sql_text(&pattern))
-            .collect::<Vec<SqlValue>>();
-        add_recall_scope(&mut conditions, &mut values, spec, "s")?;
-        values.push(to_i64(spec.limit as u64, "recall limit")?.into());
-        let order = match spec.order {
-            RecallOrder::Started => "s.started_at DESC",
-            RecallOrder::Relevance | RecallOrder::Ended => "s.ended_at DESC",
-        };
-        let sql = format!(
-            "SELECT NULL, s.id, s.source_id, s.session_key, s.session_uuid, s.title, \
-             s.summary_text, s.compact_text, s.reasoning_summary_text, s.cwd, s.started_at, \
-             s.ended_at, s.message_count, 'session_profile', NULL, NULL, NULL, '', NULL, NULL, \
-             0.0 AS score FROM sessions s \
-             WHERE {} ORDER BY {order} LIMIT ?",
-            conditions.join(" AND ")
-        );
-        let mut statement = self.connection.prepare(&sql)?;
-        let candidates = statement
-            .query_map(params_from_iter(values), candidate_v8_from_row)?
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(candidates)
-    }
-
     fn load_v8_documents(&self, session_id: i64) -> IndexResult<Vec<StoredDocument>> {
         let mut statement = self.connection.prepare(
             "SELECT id, kind, seq, role, timestamp, source_kind, body_text, title_text, \
@@ -778,51 +611,6 @@ impl IndexReader {
         let documents = statement
             .query_map([session_id], stored_document_from_row)?
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(documents)
-    }
-
-    fn load_v7_documents(&self, session: &StoredSession) -> IndexResult<Vec<StoredDocument>> {
-        let mut documents = vec![StoredDocument {
-            id: None,
-            kind: DocumentKind::SessionProfile,
-            seq: None,
-            role: None,
-            timestamp: None,
-            source_kind: None,
-            body_text: String::new(),
-            title_text: session.title.clone(),
-            summary_text: session.summary_text.clone(),
-            compact_text: session.compact_text.clone(),
-            reasoning_text: session.reasoning_summary_text.clone(),
-            raw_start: None,
-            raw_end: None,
-            projection_epoch: 1,
-        }];
-        let mut statement = self.connection.prepare(
-            "SELECT id, seq, role, timestamp, source_kind, content_text \
-             FROM messages WHERE session_id=? ORDER BY seq",
-        )?;
-        let messages = statement
-            .query_map([session.id], |row| {
-                Ok(StoredDocument {
-                    id: Some(row.get(0)?),
-                    kind: DocumentKind::Message,
-                    seq: Some(row.get(1)?),
-                    role: Some(parse_role(&row.get::<_, String>(2)?)?),
-                    timestamp: Some(row.get(3)?),
-                    source_kind: Some(row.get(4)?),
-                    body_text: row.get(5)?,
-                    title_text: String::new(),
-                    summary_text: String::new(),
-                    compact_text: String::new(),
-                    reasoning_text: String::new(),
-                    raw_start: None,
-                    raw_end: None,
-                    projection_epoch: 1,
-                })
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
-        documents.extend(messages);
         Ok(documents)
     }
 
@@ -853,9 +641,15 @@ impl IndexReader {
         if self.layout == IndexLayout::V8 {
             Ok(())
         } else {
-            Err(IndexError::InvalidOperation(format!(
-                "{operation} requires a v8 index"
-            )))
+            // Single-branch content contract: v7 is an import format only.
+            // Content-bearing commands fail closed with the typed upgrade
+            // error; the only v7 consumer is the explicit sync migration.
+            Err(IndexError::unsupported(
+                self.metadata.schema_version,
+                format!(
+                    "{operation} requires a native v8 index; the legacy v7 index is migrated by an explicit scoped `shlog sync`"
+                ),
+            ))
         }
     }
 }
@@ -979,55 +773,6 @@ pub(crate) fn inspect_v8_invariants(connection: &Connection) -> IndexResult<Inva
     }
     validate_profile_mirrors(connection, &mut report)?;
     validate_coverage_json(connection, &mut report)?;
-    Ok(report)
-}
-
-fn inspect_v7_invariants(connection: &Connection) -> IndexResult<InvariantReport> {
-    let has_message_fts = table_exists(connection, "messages_fts")?;
-    let has_session_fts = table_exists(connection, "sessions_fts")?;
-    let mut report = InvariantReport {
-        session_count: count(connection, "sessions", None)?,
-        message_document_count: count(connection, "messages", None)?,
-        profile_document_count: if has_session_fts {
-            count(connection, "sessions_fts", None)?
-        } else {
-            0
-        },
-        fts_row_count: if has_message_fts {
-            count(connection, "messages_fts", None)?
-        } else {
-            0
-        },
-        source_file_count: if table_exists(connection, "source_file_meta_cache")? {
-            count(connection, "source_file_meta_cache", None)?
-        } else {
-            0
-        },
-        coverage_count: if table_exists(connection, "coverage")? {
-            count(connection, "coverage", None)?
-        } else {
-            0
-        },
-        violations: Vec::new(),
-    };
-    collect_foreign_key_violations(connection, &mut report)?;
-    let mismatches: i64 = connection.query_row(
-        "SELECT COUNT(*) FROM sessions s WHERE s.message_count<>( \
-         SELECT COUNT(*) FROM messages m WHERE m.session_id=s.id)",
-        [],
-        |row| row.get(0),
-    )?;
-    if mismatches != 0 {
-        report.violations.push(format!(
-            "{mismatches} v7 sessions have message count mismatches"
-        ));
-    }
-    if has_message_fts && report.fts_row_count != report.message_document_count {
-        report.violations.push(format!(
-            "v7 messages_fts has {} rows for {} messages",
-            report.fts_row_count, report.message_document_count
-        ));
-    }
     Ok(report)
 }
 
@@ -1401,27 +1146,6 @@ fn recall_order_sql(
             None => relevance.to_owned(),
         },
     }
-}
-
-fn sort_candidates(candidates: &mut [CandidateEvidence], order: RecallOrder) {
-    candidates.sort_by(|left, right| match order {
-        RecallOrder::Relevance => left
-            .fts_score
-            .partial_cmp(&right.fts_score)
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| right.ended_at.cmp(&left.ended_at))
-            .then_with(|| left.seq.cmp(&right.seq)),
-        RecallOrder::Ended => right.ended_at.cmp(&left.ended_at).then_with(|| {
-            left.fts_score
-                .partial_cmp(&right.fts_score)
-                .unwrap_or(Ordering::Equal)
-        }),
-        RecallOrder::Started => right.started_at.cmp(&left.started_at).then_with(|| {
-            left.fts_score
-                .partial_cmp(&right.fts_score)
-                .unwrap_or(Ordering::Equal)
-        }),
-    });
 }
 
 fn fts_match(terms: &[String]) -> String {

--- a/rust/src/index/tests.rs
+++ b/rust/src/index/tests.rs
@@ -819,19 +819,26 @@ fn v7_reader_uses_legacy_sessions_messages_and_coverage_without_writes() {
 
     let reader = IndexReader::open(&path).unwrap();
     assert_eq!(reader.layout(), IndexLayout::V7);
+    // Status-oriented proof reads keep working on legacy layout so `status`
+    // can nudge the user toward the explicit sync migration.
     assert_eq!(reader.stats(SourceId::Codex).unwrap().message_count, 2);
+    assert!(!reader.coverage_status(&selector()).unwrap().complete);
     let session_ref = SessionRef {
         source_id: SourceId::Codex,
         native_session_id: "legacy".to_owned(),
     };
-    assert_eq!(
-        reader.read_page(&session_ref, 1, 20).unwrap().messages[0].seq,
-        1
-    );
-    let like_candidates = reader
+
+    // Content-bearing commands fail closed on v7 with the typed upgrade
+    // error; the only v7 consumer is the explicit sync migration.
+    let read_error = reader.read_page(&session_ref, 1, 20).unwrap_err();
+    assert!(matches!(
+        &read_error,
+        IndexError::UnsupportedSchema { detail, .. } if detail.contains("shlog sync")
+    ));
+    let recall_error = reader
         .recall(&RecallSpec {
-            terms: vec![],
-            like_needle: Some("l".to_owned()),
+            terms: vec!["legacy".to_owned()],
+            like_needle: None,
             sources: vec![SourceId::Codex],
             session: Some(session_ref.clone()),
             selector: None,
@@ -839,21 +846,21 @@ fn v7_reader_uses_legacy_sessions_messages_and_coverage_without_writes() {
             order: RecallOrder::Relevance,
             limit: 10,
         })
-        .unwrap();
-    assert!(
-        like_candidates
-            .iter()
-            .any(|candidate| candidate.kind == DocumentKind::Message)
-    );
-    assert!(
-        like_candidates
-            .iter()
-            .any(|candidate| candidate.kind == DocumentKind::SessionProfile)
-    );
-    let bundle = reader.export_session_bundle(&session_ref).unwrap();
-    assert_eq!(bundle.documents.len(), 3);
-    assert!(reader.coverage_status(&selector()).unwrap().complete);
-    assert!(reader.ensure_invariants().unwrap().is_valid());
+        .unwrap_err();
+    assert!(matches!(
+        &recall_error,
+        IndexError::UnsupportedSchema { .. }
+    ));
+    let bundle_error = reader.export_session_bundle(&session_ref).unwrap_err();
+    assert!(matches!(
+        &bundle_error,
+        IndexError::UnsupportedSchema { .. }
+    ));
+    let invariant_error = reader.ensure_invariants().unwrap_err();
+    assert!(matches!(
+        &invariant_error,
+        IndexError::UnsupportedSchema { .. }
+    ));
 }
 
 #[test]

--- a/rust/src/migration/legacy.rs
+++ b/rust/src/migration/legacy.rs
@@ -506,6 +506,41 @@ fn hash_bytes(hasher: &mut Hasher, value: &[u8]) {
     hasher.update(value);
 }
 
+/// Legacy v7 TEXT columns can contain bytes that are not valid UTF-8 (e.g.
+/// lone UTF-16 surrogates persisted by old JavaScript writers). The import
+/// path normalizes them lossily to U+FFFD instead of failing the whole
+/// migration on one drifted cell.
+fn legacy_text(row: &Row<'_>, index: usize) -> rusqlite::Result<String> {
+    Ok(match row.get_ref(index)? {
+        rusqlite::types::ValueRef::Text(bytes) | rusqlite::types::ValueRef::Blob(bytes) => {
+            String::from_utf8_lossy(bytes).into_owned()
+        }
+        value => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                value.data_type(),
+                "text".into(),
+            ));
+        }
+    })
+}
+
+fn legacy_optional_text(row: &Row<'_>, index: usize) -> rusqlite::Result<Option<String>> {
+    Ok(match row.get_ref(index)? {
+        rusqlite::types::ValueRef::Null => None,
+        rusqlite::types::ValueRef::Text(bytes) | rusqlite::types::ValueRef::Blob(bytes) => {
+            Some(String::from_utf8_lossy(bytes).into_owned())
+        }
+        value => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                index,
+                value.data_type(),
+                "text".into(),
+            ));
+        }
+    })
+}
+
 struct V7SessionRow {
     id: i64,
     source_id: String,
@@ -532,21 +567,21 @@ impl V7SessionRow {
     fn read(row: &Row<'_>) -> rusqlite::Result<Self> {
         Ok(Self {
             id: row.get(0)?,
-            source_id: row.get(1)?,
-            native_session_id: row.get(2)?,
-            session_key: row.get(3)?,
-            session_uuid: row.get(4)?,
-            file_path: row.get(5)?,
-            source_root: row.get(6)?,
-            title: row.get(7)?,
-            summary_text: row.get(8)?,
-            compact_text: row.get(9)?,
-            reasoning_summary_text: row.get(10)?,
-            cwd: row.get(11)?,
-            model: row.get(12)?,
-            started_at: row.get(13)?,
-            ended_at: row.get(14)?,
-            path_date: row.get(15)?,
+            source_id: legacy_text(row, 1)?,
+            native_session_id: legacy_text(row, 2)?,
+            session_key: legacy_text(row, 3)?,
+            session_uuid: legacy_text(row, 4)?,
+            file_path: legacy_text(row, 5)?,
+            source_root: legacy_text(row, 6)?,
+            title: legacy_text(row, 7)?,
+            summary_text: legacy_text(row, 8)?,
+            compact_text: legacy_text(row, 9)?,
+            reasoning_summary_text: legacy_text(row, 10)?,
+            cwd: legacy_text(row, 11)?,
+            model: legacy_text(row, 12)?,
+            started_at: legacy_text(row, 13)?,
+            ended_at: legacy_text(row, 14)?,
+            path_date: legacy_text(row, 15)?,
             message_count: row.get(16)?,
             raw_file_mtime: row.get(17)?,
             raw_file_size: row.get(18)?,
@@ -567,11 +602,11 @@ impl V7MessageRow {
     fn read(row: &Row<'_>) -> rusqlite::Result<Self> {
         Ok(Self {
             seq: row.get(0)?,
-            role: row.get(1)?,
-            content_text: row.get(2)?,
-            timestamp: row.get(3)?,
-            source_kind: row.get(4)?,
-            session_uuid: row.get(5)?,
+            role: legacy_text(row, 1)?,
+            content_text: legacy_text(row, 2)?,
+            timestamp: legacy_text(row, 3)?,
+            source_kind: legacy_text(row, 4)?,
+            session_uuid: legacy_text(row, 5)?,
         })
     }
 }
@@ -592,16 +627,16 @@ struct V7SourceFileRow {
 impl V7SourceFileRow {
     fn read(row: &Row<'_>) -> rusqlite::Result<Self> {
         Ok(Self {
-            source_id: row.get(0)?,
-            file_path: row.get(1)?,
+            source_id: legacy_text(row, 0)?,
+            file_path: legacy_text(row, 1)?,
             mtime_ms: row.get(2)?,
             size: row.get(3)?,
-            cwd: row.get(4)?,
-            path_date: row.get(5)?,
-            extra_fingerprint: row.get(6)?,
-            native_session_id: row.get(7)?,
-            session_key: row.get(8)?,
-            source_root: row.get(9)?,
+            cwd: legacy_text(row, 4)?,
+            path_date: legacy_optional_text(row, 5)?,
+            extra_fingerprint: legacy_text(row, 6)?,
+            native_session_id: legacy_optional_text(row, 7)?,
+            session_key: legacy_optional_text(row, 8)?,
+            source_root: legacy_optional_text(row, 9)?,
         })
     }
 }

--- a/rust/src/migration/tests.rs
+++ b/rust/src/migration/tests.rs
@@ -541,6 +541,38 @@ fn assert_published_cold_fence(fixture: &Fixture) {
     }
 }
 
+/// Regression for the 0.5.0/0.5.1 migration incident: old JavaScript writers
+/// could persist lone UTF-16 surrogates into TEXT columns (invalid UTF-8
+/// bytes). The import path must normalize them lossily instead of failing the
+/// whole migration on one drifted cell.
+#[test]
+fn migration_tolerates_legacy_lone_surrogate_text() {
+    let fixture = Fixture::new();
+    let connection = Connection::open(&fixture.db).unwrap();
+    // 0xED 0xA0 0xBD is the UTF-8 encoding of the lone high surrogate U+D83D.
+    connection
+        .execute(
+            "UPDATE sessions SET title = CAST(x'6c6f6e6520eda0bd737572' AS TEXT) WHERE native_session_id=?",
+            [HOT_ID],
+        )
+        .unwrap();
+    drop(connection);
+
+    let report = migrate_v7_to_v8(&fixture.request()).unwrap();
+    assert_eq!(report.session_count, 2);
+    let reader = IndexReader::open(&fixture.db).unwrap();
+    assert_eq!(reader.layout(), IndexLayout::V8);
+    let hot = reader
+        .load_session(&SessionRef {
+            source_id: SourceId::Codex,
+            native_session_id: HOT_ID.to_owned(),
+        })
+        .unwrap()
+        .unwrap();
+    assert!(hot.title.contains('\u{FFFD}'), "title: {:?}", hot.title);
+    assert!(hot.title.contains("lone"));
+}
+
 /// Regression for the 0.5.0 v7-read incident: legacy TS schema versions
 /// stored `raw_file_mtime` with REAL storage class. The migration import path
 /// must accept any numeric storage class and normalize it.

--- a/rust/src/migration/tests.rs
+++ b/rust/src/migration/tests.rs
@@ -541,6 +541,38 @@ fn assert_published_cold_fence(fixture: &Fixture) {
     }
 }
 
+/// Regression for the 0.5.0 v7-read incident: legacy TS schema versions
+/// stored `raw_file_mtime` with REAL storage class. The migration import path
+/// must accept any numeric storage class and normalize it.
+#[test]
+fn migration_tolerates_legacy_real_raw_file_mtime() {
+    let fixture = Fixture::new();
+    let connection = Connection::open(&fixture.db).unwrap();
+    // +0.5 cannot be represented losslessly under INTEGER affinity, so SQLite
+    // stores the column values with REAL storage class, like old TS writes.
+    connection
+        .execute(
+            "UPDATE sessions SET raw_file_mtime = raw_file_mtime + 0.5",
+            [],
+        )
+        .unwrap();
+    let real_rows = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE typeof(raw_file_mtime)='real'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(real_rows, 2);
+    drop(connection);
+
+    let report = migrate_v7_to_v8(&fixture.request()).unwrap();
+    assert_eq!(report.session_count, 2);
+    let reader = IndexReader::open(&fixture.db).unwrap();
+    assert_eq!(reader.layout(), IndexLayout::V8);
+    assert_eq!(reader.stats(SourceId::Codex).unwrap().session_count, 2);
+}
+
 struct Fixture {
     _temp: tempfile::TempDir,
     db: PathBuf,

--- a/rust/src/migration/verify.rs
+++ b/rust/src/migration/verify.rs
@@ -429,7 +429,10 @@ fn hash_value(hasher: &mut Hasher, value: ValueRef<'_>) {
         }
         ValueRef::Text(value) => {
             hasher.update(b"T");
-            hash_bytes(hasher, value);
+            // The import path normalizes legacy text lossily (invalid UTF-8,
+            // e.g. lone surrogates, becomes U+FFFD). Digest the normalized
+            // form so v7 and v8 agree on the declared transformation.
+            hash_bytes(hasher, String::from_utf8_lossy(value).as_bytes());
         }
         ValueRef::Blob(value) => {
             hasher.update(b"B");

--- a/rust/src/model.rs
+++ b/rust/src/model.rs
@@ -553,6 +553,10 @@ pub struct StatusContext {
 #[serde(rename_all = "camelCase")]
 pub struct StatusIndex {
     pub exists: bool,
+    /// Storage layout of the opened index: `native_v8`, `legacy_v7`, or
+    /// `none` when no index exists. `legacy_v7` is the upgrade nudge: content
+    /// commands fail closed until one explicit `shlog sync` migrates.
+    pub layout: String,
     pub session_count: u64,
     pub message_count: u64,
     pub earliest_started_at: Option<String>,
@@ -722,6 +726,7 @@ mod tests {
             },
             index: StatusIndex {
                 exists: false,
+                layout: "none".to_owned(),
                 session_count: 0,
                 message_count: 0,
                 earliest_started_at: None,

--- a/rust/src/retrieval/golden_tests.rs
+++ b/rust/src/retrieval/golden_tests.rs
@@ -82,7 +82,6 @@ fn query_analysis_matches_ts_for_cjk_paths_and_fts_escaping() {
         }
     );
     assert_eq!(analyze_query("𠮷野家").terms, strings(&["𠮷野", "野家"]));
-    assert_eq!(LEGACY_SESSION_FTS_WEIGHTS, [8.0, 3.0, 4.0, 1.2]);
     assert_eq!(
         analyze_query("汉").recall,
         RecallMode::Like {

--- a/rust/src/retrieval/mod.rs
+++ b/rust/src/retrieval/mod.rs
@@ -25,8 +25,7 @@ pub use global::{
     FindSourceSelection, merge_find_results, merge_find_summaries, public_find_sources,
 };
 pub use query::{
-    LEGACY_SESSION_FTS_WEIGHTS, QueryAnalysis, RecallMode, analyze_query, build_fts_match,
-    escape_like_pattern, quote_fts_term,
+    QueryAnalysis, RecallMode, analyze_query, build_fts_match, escape_like_pattern, quote_fts_term,
 };
 pub use ranking::{
     RetrievalPlan, rank_candidates, rank_candidates_at, rank_candidates_for_sort,

--- a/rust/src/retrieval/query.rs
+++ b/rust/src/retrieval/query.rs
@@ -1,10 +1,5 @@
 use crate::tokenizer::{has_cjk, query_terms};
 
-/// Legacy `sessions_fts` bm25 column weights: title, summary, compact,
-/// reasoning summary. The v8 documents adapter should normalize its raw
-/// candidate score to the same scale during differential rollout.
-pub const LEGACY_SESSION_FTS_WEIGHTS: [f64; 4] = [8.0, 3.0, 4.0, 1.2];
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RecallMode {
     Empty,

--- a/skill-packages/sherlog/SKILL.md
+++ b/skill-packages/sherlog/SKILL.md
@@ -34,6 +34,7 @@ description: "Use proactively for local agent-session history and prior setup ar
 | Sort | `find` 默认 relevance；最新/最近用 `--sort ended`，必要时 `--exclude-session` 防 self-hit。日期自然语言只是 query term，不是 date filter。 |
 | Query refine | 多 term 是 quoted-term AND。零结果先读 `zeroResults.reason`；不要原样重复过长 query。当前没有全正文 typo/fuzzy search。 |
 | Coverage | `find/list` 只报告 stored index proof，`freshness` 为 `not_checked`；需要 live proof 才用同 scope 的 `status --cwd/--selector`。`recommendedAction=query` 不 sync，`recommendedAction=sync` 才同步同范围。 |
+| Legacy index | `status` 的 `index.layout` 为 `legacy_v7` 时：内容命令会返回 typed `index_schema_upgrade_required`（nextAction 为 `shlog sync --db <db> --json`）。跑一次该 sync 即完成迁移（保留 `*.v7.bak.*` 备份、coverage 重建、旧 0.4.4 writer 不再可写），之后所有命令回到 v8。不要绕开这条路径去手工 patch 旧库。 |
 | Cold | v8 truth 是 SQLite `cold_roots`。`cold add` 只登记 presence；`sync` 不从 `.jsonl.zst` 重建。JSON `configPath` 是 legacy tombstone 兼容字段，不是 v8 truth。 |
 | Prune | 默认不用 `--prune`。只有用户明确要删除 hot 与 registered cold 都不存在的 projection 时才执行。registered cold root 不可达（missing/unmounted/permission）时 prune fail-closed，不会把不可读当作不存在。当前 cold-presence destructive prune 只支持 Codex。 |
 

--- a/skill-packages/sherlog/references/cli-surface.md
+++ b/skill-packages/sherlog/references/cli-surface.md
@@ -72,6 +72,7 @@ SHLOG="${SHLOG_BIN:-${CXS_BIN:-shlog}}"
 - self-hit 用 `--exclude-session`，可重复。
 - query 只读 SQLite；不扫描 raw、不检查 live freshness、不隐式 sync。coverage freshness 因此为 `not_checked`；需要 live proof 时另跑同 scope `status`。
 - JSON candidate 包含 `sessionRef`、`matchSource`、`matchSeq`、`matchedFields`、`sessionMessageCount` 与 `evidenceRead.command`（`executable:"inherit"`、`args`、`sideEffect`）。
+- `status --json` 的 `index.layout`：`native_v8` / `legacy_v7`（升级 nudge）/ `none`。
 
 ## `read-range`
 

--- a/skill-packages/sherlog/references/failure-cookbook.md
+++ b/skill-packages/sherlog/references/failure-cookbook.md
@@ -88,6 +88,15 @@ Schema 仍接受 `fresh_miss` / `stale_or_missing_coverage` 作为兼容 reason�
 
 新/未索引 active file 在建立 bounded read 前已变化，Sherlog 无法证明旧 prefix 安全。其他稳定 file 可能已提交，但 complete coverage 未写。稍后执行同范围 sync。
 
+## Legacy v7 index (升级后首次使用)
+
+`status` 的 `index.layout` 为 `legacy_v7` 时，内容命令（find/read/list）返回 typed `index_schema_upgrade_required`，`nextAction.commands[0]` 是闭包 `--db` 的 `shlog sync`。执行一次即完成迁移：
+
+- 迁移保留 `*.v7.bak.*` 一致备份，可用备份回滚；
+- 迁移后 coverage 清空，需要重新 sync 各常用 root/selector；
+- 迁移是单向的：旧 0.4.4 writer 对 v8 fail-closed；
+- 不要为绕过迁移手工 patch 旧库，或反复重试读命令。
+
 ## Strict sync failure
 
 JSON report 的 `errors` 与 `errorDetails[]` 是 per-file/source evidence。strict failure 不发布部分 complete coverage；先修 filesystem/permission/malformed source，再同范围重试。

--- a/skill-packages/sherlog/references/json-schema.md
+++ b/skill-packages/sherlog/references/json-schema.md
@@ -74,6 +74,7 @@ interface StatusPayload {
   };
   index: {
     exists: boolean;
+    layout: "native_v8" | "legacy_v7" | "none";
     sessionCount: number;
     messageCount: number;
     earliestStartedAt: string | null;
@@ -395,7 +396,7 @@ interface ErrorEnvelope {
 常见扩展：
 
 - `index_unavailable`：`dbPath`、`hint`、`nextAction.commands[].argv`；
-- `index_schema_upgrade_required`：`dbPath`、`missingColumns`、`hint`；
+- `index_schema_upgrade_required`：`dbPath`、`missingColumns`、`hint`、`nextAction`（`migrate_legacy_index`，commands 为闭包 `--db` 的 sync）；
 - `session_not_found`：`sessionRef`、`sourceId`、`nativeSessionId`、`dbPath`、`nextAction`；
 - `anchor_not_found`：`sessionRef`、`sourceId`、`nativeSessionId`、`query`、`matchedProfileFields`、`hint`、`nextAction`；
 - `unsupported_source`：`source`；

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1767,7 +1767,14 @@ describe("shlog cli", { timeout: 20_000 }, () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toBe("");
       const payload = JSON.parse(result.stdout) as {
-        error: { code: string; message: string; dbPath: string; missingColumns: string[]; hint: string };
+        error: {
+          code: string;
+          message: string;
+          dbPath: string;
+          missingColumns: string[];
+          hint: string;
+          nextAction: { commands: Array<{ argv: string[] }> };
+        };
       };
       expect(payload.error.code).toBe("index_schema_upgrade_required");
       expect(payload.error.message).toContain(dbPath);
@@ -1778,7 +1785,8 @@ describe("shlog cli", { timeout: 20_000 }, () => {
         "sessions.session_key",
         "coverage.source_id",
       ]);
-      expect(payload.error.hint).toContain("shlog sync --source codex");
+      expect(payload.error.hint).toContain("shlog sync");
+      expect(payload.error.nextAction.commands[0].argv).toEqual(["shlog", "sync", "--db", dbPath, "--json"]);
       expect(result.stdout).not.toContain("SqliteError");
       expect(result.stdout).not.toContain("no such column");
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -952,7 +952,9 @@ function shellArg(value: string): string {
 
 function emitIndexSchemaUpgradeRequiredError(error: IndexSchemaUpgradeRequiredError, jsonMode: boolean): void {
   const hint =
-    `Run \`${PROGRAM_NAME} sync --source codex --root <sessions-root>\` or the equivalent scoped sync to migrate the index, then retry.`;
+    "A supported v7 index is migrated only by an explicit scoped `shlog sync`. " +
+    "For a newer or incompatible v8 version/epoch, use a compatible `shlog` binary " +
+    "or restore a trusted backup; repeated sync will not make it compatible.";
   if (jsonMode) {
     console.log(
       JSON.stringify(
@@ -963,6 +965,17 @@ function emitIndexSchemaUpgradeRequiredError(error: IndexSchemaUpgradeRequiredEr
             dbPath: error.dbPath,
             missingColumns: error.missingColumns,
             hint,
+            nextAction: {
+              kind: "migrate_legacy_index",
+              reason: "index_schema_upgrade_required",
+              commands: [
+                {
+                  label: "migrate legacy index with sync",
+                  recommended: true,
+                  argv: [PROGRAM_NAME, "sync", "--db", error.dbPath, "--json"],
+                },
+              ],
+            },
           },
         },
         null,

--- a/src/index-sidecar-sqlite.ts
+++ b/src/index-sidecar-sqlite.ts
@@ -107,6 +107,7 @@ function readIndexStatus(db: Db, dbPath: string, sourceId: SessionSourceId): Ind
       : getStatsCounts(db, sourceId);
   return {
     exists: true,
+    layout: "legacy_v7",
     sessionCount: counts.sessionCount,
     messageCount: counts.messageCount,
     earliestStartedAt: counts.earliestStartedAt,

--- a/src/index-sidecar.ts
+++ b/src/index-sidecar.ts
@@ -128,6 +128,7 @@ export function readIndexSidecar(dbPath: string): IndexSidecar | null {
 export function emptyIndexStatus(): StatusSummary["index"] {
   return {
     exists: false,
+    layout: "none",
     sessionCount: 0,
     messageCount: 0,
     earliestStartedAt: null,
@@ -183,6 +184,7 @@ function fileMetaMap(entries: IndexSidecarFileMeta[]): Map<string, SourceFileMet
 function indexStatusFromSlice(dbPath: string, slice: IndexSidecarSourceSlice | undefined): StatusSummary["index"] {
   return {
     exists: true,
+    layout: "legacy_v7",
     sessionCount: slice?.sessionCount ?? 0,
     messageCount: slice?.messageCount ?? 0,
     earliestStartedAt: slice?.earliestStartedAt ?? null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -372,6 +372,7 @@ export interface StatusSummary {
   sourceInventory: SourceInventory;
   index: {
     exists: boolean;
+    layout: "native_v8" | "legacy_v7" | "none";
     sessionCount: number;
     messageCount: number;
     earliestStartedAt: string | null;


### PR DESCRIPTION
## 动机

0.5.0 的 v7 读兼容（双 recall SQL、双排序权重、双 message 查询）在发布当天撞出真实 bug：legacy TS 索引把 `raw_file_mtime` 存成 REAL，v7 读路径硬读 i64，导致 `read-range` 在 ~6k 真实 session 上直接崩（`Invalid column type Real`）。

不是加固第二条分支，而是把它删掉——查询面回到单分支。

## 变更

- **v7 只作为 migration 的 import 格式**：删除 recall_v7 家族、v7 messages SQL、load_v7_documents、inspect_v7_invariants、LEGACY_SESSION_FTS_WEIGHTS（净 -80 行）。migration 模块是唯一 v7 消费方（其 integer_mtime 本就防御 REAL），新增 REAL raw_file_mtime 回归测试。
- **legacy 索引上的内容命令 fail-closed**：find/read/list 返回 typed `index_schema_upgrade_required`，nextAction 为闭包 `--db` 的 `shlog sync --json`；一次 sync 完成迁移+coverage 重建。
- **status 升级 nudge**：对 legacy 索引正常工作，新增 `index.layout`（native_v8 | legacy_v7 | none）。
- **升级 UX**（无 auto-update，主动升级）：status 看到 legacy_v7 → 内容命令指路一次 sync → 迁移保留 `*.v7.bak.*` 备份、coverage 清空、legacy cold-roots.json tombstone、旧 0.4.4 writer fail-closed。
- TS oracle 镜像 contract 可见变更；contract gate 将 layout 归一化为 epoch-opaque。

## 验证

- cargo fmt/clippy -D warnings；Rust 183 lib + 12 CLI
- tsc + 285 TS
- native contract 27/27；native acceptance 8/8
- 端到端实证：v7 库 find → typed error；sync → 迁移成功；find 恢复；status layout legacy_v7 → native_v8

## Mainline

intent `int_9e537e35` sealed（commit e29d222），无 phase-1 conflict。