### PR TITLE
feat: add DSH source for searching ~/.dsh session history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## 项目定位
 
-`Sherlog`（CLI 命令 `shlog`）是一个面向本机 agent session 日志的渐进式检索 CLI。生产 runtime 已切换为 standalone Rust binary，内置 SQLite/FTS5；使用者运行 CLI 不需要 Node.js。当前公开 source 包括 `codex`、experimental `claude-code` 和 experimental `pi`。
+`Sherlog`（CLI 命令 `shlog`）是一个面向本机 agent session 日志的渐进式检索 CLI。生产 runtime 已切换为 standalone Rust binary，内置 SQLite/FTS5；使用者运行 CLI 不需要 Node.js。当前公开 source 包括 `codex`、experimental `claude-code`、experimental `pi` 和 experimental `dsh`。
 
 当前接受的产品边界：
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -448,6 +450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +708,7 @@ dependencies = [
  "unicode-script",
  "unicode-segmentation",
  "walkdir",
+ "zstd",
 ]
 
 [[package]]
@@ -909,3 +922,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ query/list/read --------------------------+--> progressive evidence read
 status --(read-only allowlisted inventory scan)--> live coverage diagnosis
 ```
 
-它不是 GUI、watcher、daemon、实时同步服务，也不把 raw grep 当作正常查询路径。当前公开 source 是 `codex`、experimental `claude-code` 与 experimental `pi`。
+它不是 GUI、watcher、daemon、实时同步服务，也不把 raw grep 当作正常查询路径。当前公开 source 是 `codex`、experimental `claude-code`、experimental `pi` 与 experimental `dsh`。
 
 ## Runtime 与命令权限
 

--- a/docs/INDEX_COVERAGE_DESIGN.md
+++ b/docs/INDEX_COVERAGE_DESIGN.md
@@ -4,7 +4,7 @@
 
 ## 范围与真相源
 
-当前 public source：`codex`、experimental `claude-code`、experimental `pi`。Coverage 是 SQLite v8 对 canonical selector 的 stored sync proof，不是内容副本，也不是 live filesystem 状态。
+当前 public source：`codex`、experimental `claude-code`、experimental `pi`、experimental `dsh`。Coverage 是 SQLite v8 对 canonical selector 的 stored sync proof，不是内容副本，也不是 live filesystem 状态。
 
 - 内容真相来自 privacy-filtered `documents` projection。
 - 在 `shlog` CLI 内，raw transcript 只由 `sync` 做 bounded projection，或由 `status` 在 inventory cache miss 时流式解析 accepted projection；query/read 不读取 raw。

--- a/docs/RUST_ARCHITECTURE.md
+++ b/docs/RUST_ARCHITECTURE.md
@@ -129,7 +129,7 @@ v8 的持久 journal policy 是 `DELETE + synchronous=FULL`，不是 WAL。外�
 - malformed/filtered record 遵守 source contract；
 - 不把 tool result、thinking、attachment、diagnostic 等默认写入搜索面。
 
-`claude-code` 与 `pi` 是 experimental raw reader，不是上游格式稳定承诺。
+`claude-code`、`pi` 与 `dsh` 是 experimental raw reader，不是上游格式稳定承诺。
 
 ## Incremental sync
 

--- a/docs/SOURCE_CONTRACTS.md
+++ b/docs/SOURCE_CONTRACTS.md
@@ -130,13 +130,15 @@ Pi currently requests full replay when an existing checkpoint is offered (`Delta
 
 Implementation: `rust/src/sources/dsh.rs`.
 
-Source layout: `~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`. The file is zstd-compressed JSONL; the adapter treats the compressed file as the raw source and streams decompressed records.
+Source layout: `~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`. The file is zstd-compressed JSONL; the adapter treats the compressed file as the raw source and streams decompressed records. Scan accepts only `.zstd`/`.zst` files; an uncompressed `.jsonl` in the tree is skipped as format drift, not decoded.
+
+DSH session archiving is a workspace UI flag (`~/.dsh/storages/workspace.json` `archivedSessionIds`); archived session files stay in place under the sessions root, so they remain indexed and searchable. Sherlog does not read or replicate the archive flag.
 
 Accepted metadata/profile input:
 
-- `session` record with non-empty cwd and `createdAt` epoch millis -> ISO timestamp; id when available;
-- `session/title` non-empty title;
-- `request/header` non-empty `data.header.config.model`.
+- `session` record with non-empty cwd and `createdAt` epoch millis -> ISO timestamp; id when available (fallback: the session directory name);
+- latest `session/title` non-empty title (the first title is a truncated paste of the first user message; later records carry the refined title);
+- latest `request/header` non-empty `data.header.config.model` (the model can switch mid-session).
 
 Accepted message input:
 
@@ -153,6 +155,8 @@ Rejected:
 - malformed/non-object lines.
 
 DSH currently requests full replay when an existing checkpoint is offered (`DeltaUnsupported`). Raw byte locators are `0` because decompressed JSONL offsets are not linear in the compressed file; `read-*` serves text from SQLite.
+
+A torn final zstd frame (interrupted or in-flight write; DSH repairs torn tails itself) ends the decodable record stream without failing the file: the complete prefix is projected, and the next sync replays in full once the file is repaired. Any other decode failure (corrupt header, corrupt block, bad frame parameter) remains a hard per-file error.
 
 ## Derived profile fields
 

--- a/docs/SOURCE_CONTRACTS.md
+++ b/docs/SOURCE_CONTRACTS.md
@@ -1,6 +1,6 @@
 # Source Adapter Contracts
 
-This document defines the searchable projection contract for the native Rust source adapters. It is not a promise that upstream transcript formats are stable. `claude-code` and `pi` remain experimental transcript readers.
+This document defines the searchable projection contract for the native Rust source adapters. It is not a promise that upstream transcript formats are stable. `claude-code`, `pi`, and `dsh` remain experimental transcript readers.
 
 ## Public seam
 
@@ -10,7 +10,7 @@ This document defines the searchable projection contract for the native Rust sou
 - projection converts one byte-bounded `SourceFile` into a privacy-reviewed `SessionProjection`, accepted message documents, `ReadProof`, and an opaque checkpoint.
 - source-specific JSON keys, allowlists, reducer state, and raw-format drift remain private adapter implementation.
 
-The registry is static: `codex`, `claude-code`, `pi`. Adding a runtime plugin is not part of this contract.
+The registry is static: `codex`, `claude-code`, `pi`, `dsh`. Adding a runtime plugin is not part of this contract.
 
 ## Shared invariants
 
@@ -125,6 +125,34 @@ Rejected:
 - malformed/non-object lines.
 
 Pi currently requests full replay when an existing checkpoint is offered (`DeltaUnsupported`).
+
+## DSH adapter (experimental)
+
+Implementation: `rust/src/sources/dsh.rs`.
+
+Source layout: `~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`. The file is zstd-compressed JSONL; the adapter treats the compressed file as the raw source and streams decompressed records.
+
+Accepted metadata/profile input:
+
+- `session` record with non-empty cwd and `createdAt` epoch millis -> ISO timestamp; id when available;
+- `session/title` non-empty title;
+- `request/header` non-empty `data.header.config.model`.
+
+Accepted message input:
+
+- `user/message` only when `data.source.kind == "user"` (real user turns; injected plugin/skill-catalog/agent-instructions/subagent context is rejected);
+- `assistant/message` with `data.message.role == "assistant"`;
+- `content[]` items with `type = "text"` only;
+- timestamp from record `time` epoch millis.
+
+Rejected:
+
+- user messages with non-`user` source kind (system/runtime injections);
+- reasoning, tool-call, tool-result, and unsupported content parts;
+- incomplete session/message records;
+- malformed/non-object lines.
+
+DSH currently requests full replay when an existing checkpoint is offered (`DeltaUnsupported`). Raw byte locators are `0` because decompressed JSONL offsets are not linear in the compressed file; `read-*` serves text from SQLite.
 
 ## Derived profile fields
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,6 +83,7 @@ shlog find "X" --cwd /Users/you/work/project --sort ended \
 - `codex`
 - `claude-code`（experimental transcript reader）
 - `pi`（experimental transcript reader）
+- `dsh`（experimental zstd transcript reader）
 
 默认 root：
 
@@ -90,6 +91,7 @@ shlog find "X" --cwd /Users/you/work/project --sort ended \
 codex        ~/.codex/sessions
 claude-code  ~/.claude/projects
 pi           ~/.pi/agent/sessions
+dsh          ~/.dsh/sessions
 ```
 
 `find` 省略 `--source` 时跨所有公开 source 搜索；`--source all` 等价。`status`、`sync`、`list`、`stats` 省略时默认 Codex。bare session id 也按 Codex 解释，跨 source 请直接使用 `find` 返回的 `sessionRef`：

--- a/eval/acceptance-gate.ts
+++ b/eval/acceptance-gate.ts
@@ -5,7 +5,7 @@ import { resolveCliUnderTest, runCliUnderTest, type CliUnderTest } from "./cli-u
 import { buildDogfoodScoreboard, desiredContextMode, evaluateDogfoodItem, type DogfoodEvaluation, type DogfoodScoreboard } from "./dogfood-eval-core";
 import type { DogfoodGolden } from "./dogfood-schema";
 import { measureReturnedContext, summarizeReturnedContext, type ReturnedContextMetric, type ReturnedContextSummary } from "./returned-context";
-import type { FindResult, SyncSummary } from "../src/types";
+import type { FindResult, SessionSourceId, SyncSummary } from "../src/types";
 
 const MESSAGE_HIT_SESSION = "11111111-1111-4111-8111-111111111111";
 const SESSION_HIT_SESSION = "22222222-2222-4222-8222-222222222222";
@@ -25,7 +25,11 @@ const COMMAND_EXEC_SESSION = "77777777-7777-4777-8777-777777777777";
 const COMMAND_RESTATE_SESSION = "88888888-8888-4888-8888-888888888888";
 const QUERY_WINDOW_SESSION = "99999999-9999-4999-8999-999999999999";
 
-type AcceptanceSourceId = "codex" | "claude-code" | "pi";
+// Sources with synthetic acceptance fixtures. dsh is deliberately absent:
+// its transcripts are zstd-compressed and the TS oracle stub cannot parse
+// them, so dsh coverage lives in the native Rust e2e tests instead.
+const ACCEPTANCE_SOURCE_IDS = ["codex", "claude-code", "pi"] as const;
+type AcceptanceSourceId = (typeof ACCEPTANCE_SOURCE_IDS)[number];
 
 export type AcceptanceFixtureRoots = Record<AcceptanceSourceId, string>;
 const ROOT = resolve(import.meta.dirname, "..");
@@ -113,6 +117,20 @@ export async function runAcceptanceGate(options: AcceptanceGateOptions = {}): Pr
   }
 }
 
+function acceptanceFixtureRoot(
+  roots: AcceptanceFixtureRoots,
+  sourceId: SessionSourceId,
+  caseId: string,
+): string {
+  if ((ACCEPTANCE_SOURCE_IDS as readonly string[]).includes(sourceId)) {
+    return roots[sourceId as AcceptanceSourceId];
+  }
+  throw new Error(
+    `acceptance case ${caseId} targets source "${sourceId}", which has no acceptance fixture root; ` +
+    "pass find.root explicitly or add a real fixture",
+  );
+}
+
 async function syncSource(
   cli: CliUnderTest,
   dbPath: string,
@@ -180,7 +198,7 @@ async function findViaCli(
   if (item.find?.selector) {
     args.push("--selector", JSON.stringify(item.find.selector));
   } else {
-    args.push("--root", item.find?.root ?? roots[sourceId as AcceptanceSourceId]);
+    args.push("--root", item.find?.root ?? acceptanceFixtureRoot(roots, sourceId, item.id));
     if (item.find?.cwd) args.push("--cwd", item.find.cwd);
   }
   if (item.find?.sort) args.push("--sort", item.find.sort);

--- a/eval/acceptance-gate.ts
+++ b/eval/acceptance-gate.ts
@@ -180,7 +180,7 @@ async function findViaCli(
   if (item.find?.selector) {
     args.push("--selector", JSON.stringify(item.find.selector));
   } else {
-    args.push("--root", item.find?.root ?? roots[sourceId]);
+    args.push("--root", item.find?.root ?? roots[sourceId as AcceptanceSourceId]);
     if (item.find?.cwd) args.push("--cwd", item.find.cwd);
   }
   if (item.find?.sort) args.push("--sort", item.find.sort);

--- a/eval/contract-gate.ts
+++ b/eval/contract-gate.ts
@@ -509,6 +509,13 @@ function normalizeIntentionalV8Differences(
           if (isRecord(entry)) normalizeQueryOnlyCoverage(entry.coverage);
         }
       }
+      // Intentional v8 divergence: the legacy oracle still wraps non-fresh
+      // coverage into a check_coverage_then_retry nextAction, while native v8
+      // emits find nextAction only for zero-result diagnosis and surfaces the
+      // same state via coverageBySource. The dsh oracle adapter is a stub that
+      // can never be synced in this fixture, so the oracle always emits the
+      // coverage advice for the all-source and unscoped cases.
+      delete output.nextAction;
     }
   }
 

--- a/eval/contract-gate.ts
+++ b/eval/contract-gate.ts
@@ -651,7 +651,7 @@ function assertContractObservation(
       expectPath(json, ["results", 0, "sessionRef"], CLAUDE_SESSION_REF, definition.id);
       break;
     case "find-all-sources": {
-      expectContract(deepPathEqual(json, ["sourceIds"], ["codex", "claude-code", "pi"]), definition.id, "all-source find sourceIds changed");
+      expectContract(deepPathEqual(json, ["sourceIds"], ["codex", "claude-code", "pi", "dsh"]), definition.id, "all-source find sourceIds changed");
       const sources = Array.isArray(json?.results)
         ? json.results.map((entry) => isRecord(entry) ? entry.sourceId : null).sort()
         : [];

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "2"
 unicode-script = "0.5.8"
 unicode-segmentation = "1.13.3"
 walkdir = "2.5"
+zstd = "0.13"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/src/app/tests.rs
+++ b/rust/src/app/tests.rs
@@ -248,13 +248,7 @@ fn write_dsh_zstd_session(path: &Path, id: &str, messages: &[(&str, &str)]) {
             );
         }
     }
-    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
-    for line in lines {
-        encoder.write_all(line.as_bytes()).unwrap();
-        encoder.write_all(b"\n").unwrap();
-    }
-    let bytes = encoder.finish().unwrap();
-    std::fs::write(path, bytes).unwrap();
+    crate::sources::write_zstd_lines(path, &lines);
 }
 
 fn cached_source_file_state(file: &SourceFile, root: &Path) -> SourceFileState {
@@ -964,7 +958,7 @@ fn dsh_sync_find_read_page_round_trip() {
             "--source".to_owned(),
             "dsh".to_owned(),
             "--db".to_owned(),
-            db,
+            db.clone(),
             "--json".to_owned(),
         ],
     );
@@ -974,6 +968,43 @@ fn dsh_sync_find_read_page_round_trip() {
     assert_eq!(page["totalCount"], 2);
     assert_eq!(page["messages"][0]["contentText"], "dsh e2e query");
     assert_eq!(page["messages"][1]["contentText"], "dsh e2e answer");
+
+    let (code, stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "list".to_owned(),
+            "--source".to_owned(),
+            "dsh".to_owned(),
+            "--db".to_owned(),
+            db.clone(),
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let list: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(list["results"].as_array().unwrap().len(), 1);
+    assert_eq!(list["results"][0]["sessionUuid"], format!("dsh:{id}"));
+    assert_eq!(list["results"][0]["messageCount"], 2);
+
+    let (code, stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "stats".to_owned(),
+            "--source".to_owned(),
+            "dsh".to_owned(),
+            "--db".to_owned(),
+            db,
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let stats: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(stats["sessionCount"], 1);
+    assert_eq!(stats["messageCount"], 2);
 }
 
 #[test]

--- a/rust/src/app/tests.rs
+++ b/rust/src/app/tests.rs
@@ -34,6 +34,7 @@ fn resolved_paths(directory: &TempDir, raw_root: &Path) -> ResolvedPaths {
         default_codex_dir: raw_root.to_path_buf(),
         default_claude_code_dir: directory.path().join("missing-claude"),
         default_pi_dir: directory.path().join("missing-pi"),
+        default_dsh_dir: directory.path().join("missing-dsh"),
         legacy_data_dirs: vec![],
     }
 }
@@ -193,6 +194,67 @@ fn write_codex_session(path: &Path, id: &str, messages: &[(&str, &str)]) {
         );
     }
     std::fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
+}
+
+fn write_dsh_zstd_session(path: &Path, id: &str, messages: &[(&str, &str)]) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let mut lines = vec![
+        serde_json::json!({
+            "type": "session",
+            "version": 0,
+            "id": id,
+            "createdAt": 1786870711696i64,
+            "cwd": "/repo",
+        })
+        .to_string(),
+        serde_json::json!({
+            "type": "session/title",
+            "seq": 0,
+            "time": 1786870711696i64,
+            "data": {"title": "dsh e2e title"},
+        })
+        .to_string(),
+    ];
+    for (index, (kind, message)) in messages.iter().enumerate() {
+        let time = 1786870711696i64 + (index as i64 + 1) * 1000;
+        if *kind == "user" {
+            lines.push(
+                serde_json::json!({
+                    "type": "user/message",
+                    "seq": index + 1,
+                    "time": time,
+                    "data": {
+                        "source": {"kind": "user"},
+                        "role": "user",
+                        "content": [{"type": "text", "text": message}],
+                    },
+                })
+                .to_string(),
+            );
+        } else {
+            lines.push(
+                serde_json::json!({
+                    "type": "assistant/message",
+                    "seq": index + 1,
+                    "time": time,
+                    "data": {
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": message}],
+                        }
+                    },
+                })
+                .to_string(),
+            );
+        }
+    }
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
+    for line in lines {
+        encoder.write_all(line.as_bytes()).unwrap();
+        encoder.write_all(b"\n").unwrap();
+    }
+    let bytes = encoder.finish().unwrap();
+    std::fs::write(path, bytes).unwrap();
 }
 
 fn cached_source_file_state(file: &SourceFile, root: &Path) -> SourceFileState {
@@ -834,6 +896,84 @@ fn native_sync_handles_first_noop_append_and_imports_pending_cold_roots() {
         .unwrap();
     assert_eq!(page.total_count, 2);
     assert_eq!(page.messages[1].content_text, "append evidence");
+}
+
+#[test]
+fn dsh_sync_find_read_page_round_trip() {
+    let directory = TempDir::new().unwrap();
+    let root = directory.path().join("dsh-sessions");
+    let id = "session-dsh-e2e";
+    let raw = root.join("--repo--").join(id).join("session.jsonl.zstd");
+    write_dsh_zstd_session(
+        &raw,
+        id,
+        &[("user", "dsh e2e query"), ("assistant", "dsh e2e answer")],
+    );
+    let paths = resolved_paths(&directory, &root);
+    let mut services = NativeAppServices::new(paths.clone(), directory.path().to_path_buf());
+    let db = paths.db_path.to_string_lossy().into_owned();
+    let root_text = root.to_string_lossy().into_owned();
+
+    let (code, stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "sync".to_owned(),
+            "--source".to_owned(),
+            "dsh".to_owned(),
+            "--root".to_owned(),
+            root_text.clone(),
+            "--db".to_owned(),
+            db.clone(),
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let sync: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(sync["added"], 1);
+
+    let (code, stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "find".to_owned(),
+            "dsh e2e".to_owned(),
+            "--source".to_owned(),
+            "dsh".to_owned(),
+            "--root".to_owned(),
+            root_text,
+            "--db".to_owned(),
+            db.clone(),
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let find: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(find["results"][0]["sourceId"], "dsh");
+    assert_eq!(find["results"][0]["sessionRef"], format!("dsh:{id}"));
+    assert_eq!(find["results"][0]["matchSeq"], 0);
+
+    let (code, stdout, stderr) = run_cli(
+        &mut services,
+        vec![
+            "shlog".to_owned(),
+            "read-page".to_owned(),
+            format!("dsh:{id}"),
+            "--source".to_owned(),
+            "dsh".to_owned(),
+            "--db".to_owned(),
+            db,
+            "--json".to_owned(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let page: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(page["totalCount"], 2);
+    assert_eq!(page["messages"][0]["contentText"], "dsh e2e query");
+    assert_eq!(page["messages"][1]["contentText"], "dsh e2e answer");
 }
 
 #[test]

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -78,6 +78,7 @@ pub struct ResolvedPaths {
     pub default_codex_dir: PathBuf,
     pub default_claude_code_dir: PathBuf,
     pub default_pi_dir: PathBuf,
+    pub default_dsh_dir: PathBuf,
     pub legacy_data_dirs: Vec<PathBuf>,
 }
 
@@ -87,6 +88,7 @@ impl ResolvedPaths {
             SourceId::Codex => &self.default_codex_dir,
             SourceId::ClaudeCode => &self.default_claude_code_dir,
             SourceId::Pi => &self.default_pi_dir,
+            SourceId::Dsh => &self.default_dsh_dir,
         }
     }
 }
@@ -119,6 +121,7 @@ pub fn resolve_paths(env: &EnvSnapshot, cwd: &Path, home: &Path) -> ResolvedPath
         default_codex_dir: resolve_lexical(home.join(".codex/sessions"), cwd),
         default_claude_code_dir: resolve_lexical(home.join(".claude/projects"), cwd),
         default_pi_dir: resolve_lexical(home.join(".pi/agent/sessions"), cwd),
+        default_dsh_dir: resolve_lexical(home.join(".dsh/sessions"), cwd),
         legacy_data_dirs,
     }
 }
@@ -438,6 +441,10 @@ mod tests {
             Path::new("/Users/tester/.pi/agent/sessions")
         );
         assert_eq!(
+            resolved.default_source_root(SourceId::Dsh),
+            Path::new("/Users/tester/.dsh/sessions")
+        );
+        assert_eq!(
             resolved.legacy_data_dirs,
             [
                 PathBuf::from("/state/cxs"),
@@ -580,6 +587,7 @@ mod tests {
             default_codex_dir: base.path().join("codex"),
             default_claude_code_dir: base.path().join("claude"),
             default_pi_dir: base.path().join("pi"),
+            default_dsh_dir: base.path().join("dsh"),
             legacy_data_dirs: vec![first.clone(), second.clone()],
         };
 
@@ -609,6 +617,7 @@ mod tests {
             default_codex_dir: base.path().join("codex"),
             default_claude_code_dir: base.path().join("claude"),
             default_pi_dir: base.path().join("pi"),
+            default_dsh_dir: base.path().join("dsh"),
             legacy_data_dirs: vec![legacy.clone(), legacy.clone()],
         };
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -199,7 +199,7 @@ impl AppError {
                 format!("Rust CLI scaffold does not implement `{operation}` yet.")
             }
             Self::UnsupportedSource { source } => format!(
-                "unsupported source \"{source}\". Public sources in this release: codex|claude-code|pi."
+                "unsupported source \"{source}\". Public sources in this release: codex|claude-code|pi|dsh."
             ),
             Self::IndexUnavailable { db_path, .. } => format!("index not found: {db_path}"),
             Self::SessionNotFound { session_ref, .. } => {

--- a/rust/src/identity.rs
+++ b/rust/src/identity.rs
@@ -29,16 +29,18 @@ pub enum SourceId {
     Codex,
     ClaudeCode,
     Pi,
+    Dsh,
 }
 
 impl SourceId {
-    pub const ALL: [Self; 3] = [Self::Codex, Self::ClaudeCode, Self::Pi];
+    pub const ALL: [Self; 4] = [Self::Codex, Self::ClaudeCode, Self::Pi, Self::Dsh];
 
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Codex => "codex",
             Self::ClaudeCode => "claude-code",
             Self::Pi => "pi",
+            Self::Dsh => "dsh",
         }
     }
 }
@@ -57,6 +59,7 @@ impl FromStr for SourceId {
             "codex" => Ok(Self::Codex),
             "claude-code" => Ok(Self::ClaudeCode),
             "pi" => Ok(Self::Pi),
+            "dsh" => Ok(Self::Dsh),
             _ => Err(UnsupportedSourceId(value.to_owned())),
         }
     }
@@ -69,7 +72,7 @@ impl fmt::Display for UnsupportedSourceId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "unsupported source {:?}; expected codex, claude-code, or pi",
+            "unsupported source {:?}; expected codex, claude-code, pi, or dsh",
             self.0
         )
     }

--- a/rust/src/retrieval/golden_tests.rs
+++ b/rust/src/retrieval/golden_tests.rs
@@ -368,7 +368,12 @@ fn zero_result_helpers_match_ts_mixed_language_guidance() {
 fn global_merge_uses_rrf_and_stable_cross_source_order() {
     assert_eq!(
         public_find_sources(None, None),
-        vec![SourceId::Codex, SourceId::ClaudeCode, SourceId::Pi]
+        vec![
+            SourceId::Codex,
+            SourceId::ClaudeCode,
+            SourceId::Pi,
+            SourceId::Dsh
+        ]
     );
     assert_eq!(
         public_find_sources(Some(FindSourceSelection::All), Some(SourceId::Pi)),

--- a/rust/src/sources/catalog.rs
+++ b/rust/src/sources/catalog.rs
@@ -233,7 +233,10 @@ impl SourceCatalog {
 fn source_file_accepted(source_id: SourceId, path: &Path) -> bool {
     let extension = path.extension().and_then(|value| value.to_str());
     match source_id {
-        SourceId::Dsh => matches!(extension, Some("jsonl" | "zstd" | "zst")),
+        // DSH sessions are always zstd-compressed; the adapter decodes every
+        // accepted file as zstd, so accepting a plain `.jsonl` here would turn
+        // format drift into a hard sync failure instead of a skip.
+        SourceId::Dsh => matches!(extension, Some("zstd" | "zst")),
         _ => extension == Some("jsonl"),
     }
 }

--- a/rust/src/sources/catalog.rs
+++ b/rust/src/sources/catalog.rs
@@ -16,11 +16,12 @@ use super::{
     ProjectionCheckpoint, ProjectionOutcome, SourceError, SourceFile, SourceMetadataCache,
     SourceScan, SourceScanFailure,
 };
-use super::{claude_code, codex, pi};
+use super::{claude_code, codex, dsh, pi};
 
 const CODEX_ACCEPTED_PREFIX: &str = "accepted-v1:codex:";
 const CLAUDE_ACCEPTED_PREFIX: &str = "accepted-v1:claude-code:";
 const PI_ACCEPTED_PREFIX: &str = "accepted-v1:pi:";
+const DSH_ACCEPTED_PREFIX: &str = "accepted-v1:dsh:";
 
 #[derive(Clone, Debug)]
 pub(crate) struct AcceptedMetadata {
@@ -115,9 +116,7 @@ impl SourceCatalog {
                         .unwrap_or_else(|| std::io::Error::other("source traversal failed")),
                 )
             })?;
-            if !entry.file_type().is_file()
-                || entry.path().extension().and_then(|value| value.to_str()) != Some("jsonl")
-            {
+            if !entry.file_type().is_file() || !source_file_accepted(source_id, entry.path()) {
                 continue;
             }
             if entry.path().to_str().is_none() {
@@ -226,7 +225,16 @@ impl SourceCatalog {
             SourceId::Codex => codex::project(file, read_limit, checkpoint),
             SourceId::ClaudeCode => claude_code::project(file, read_limit, checkpoint),
             SourceId::Pi => pi::project(file, read_limit, checkpoint),
+            SourceId::Dsh => dsh::project(file, read_limit, checkpoint),
         }
+    }
+}
+
+fn source_file_accepted(source_id: SourceId, path: &Path) -> bool {
+    let extension = path.extension().and_then(|value| value.to_str());
+    match source_id {
+        SourceId::Dsh => matches!(extension, Some("jsonl" | "zstd" | "zst")),
+        _ => extension == Some("jsonl"),
     }
 }
 
@@ -245,6 +253,7 @@ fn accepted_metadata(
         SourceId::Codex => codex::inventory_metadata(path).map(Some),
         SourceId::ClaudeCode => claude_code::inventory_metadata(path),
         SourceId::Pi => pi::inventory_metadata(path),
+        SourceId::Dsh => dsh::inventory_metadata(path),
     }
 }
 
@@ -253,6 +262,7 @@ fn accepted_fingerprint_prefix(source_id: SourceId) -> &'static str {
         SourceId::Codex => CODEX_ACCEPTED_PREFIX,
         SourceId::ClaudeCode => CLAUDE_ACCEPTED_PREFIX,
         SourceId::Pi => PI_ACCEPTED_PREFIX,
+        SourceId::Dsh => DSH_ACCEPTED_PREFIX,
     }
 }
 

--- a/rust/src/sources/dsh.rs
+++ b/rust/src/sources/dsh.rs
@@ -130,15 +130,14 @@ pub(crate) fn project(
             }
             return Ok(());
         }
-        if let Some(candidate) = accepted_title(record)
-            && title.is_empty()
-        {
+        // Latest wins: DSH first writes a truncated paste of the first user
+        // message as the title, then replaces it with the LLM-refined title.
+        if let Some(candidate) = accepted_title(record) {
             title = candidate;
             return Ok(());
         }
-        if let Some(candidate) = accepted_model(record)
-            && model.is_empty()
-        {
+        // Latest wins: the model can switch mid-session.
+        if let Some(candidate) = accepted_model(record) {
             model = candidate;
             return Ok(());
         }
@@ -185,7 +184,16 @@ pub(crate) fn project(
     }
 
     let native_session_id = if session_id.is_empty() {
-        fallback_session_id(file)
+        // The DSH layout keeps the native id in the parent directory:
+        // <root>/<encoded-cwd>/<session-id>/session.jsonl.zstd. The shared
+        // file-stem fallback would see only "session.jsonl".
+        file.file_path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| fallback_session_id(file))
     } else {
         session_id
     };
@@ -231,13 +239,14 @@ fn accepted_session(record: &Map<String, Value>) -> Option<AcceptedSession> {
         return None;
     }
     let cwd = string(record, "cwd");
-    if cwd.is_empty() {
+    let timestamp = millis_timestamp(record, "createdAt");
+    if cwd.is_empty() || timestamp.is_empty() {
         return None;
     }
     Some(AcceptedSession {
         session_id: string(record, "id"),
         cwd,
-        timestamp: millis_timestamp(record, "createdAt"),
+        timestamp,
     })
 }
 
@@ -251,13 +260,14 @@ fn accepted_user_message(record: &Map<String, Value>) -> Option<AcceptedMessage>
         return None;
     }
     let content_text = text_from_content(data.get("content")?);
-    if content_text.is_empty() {
+    let timestamp = millis_timestamp(record, "time");
+    if content_text.is_empty() || timestamp.is_empty() {
         return None;
     }
     Some(AcceptedMessage {
         role: MessageRole::User,
         content_text,
-        timestamp: millis_timestamp(record, "time"),
+        timestamp,
     })
 }
 
@@ -271,13 +281,14 @@ fn accepted_assistant_message(record: &Map<String, Value>) -> Option<AcceptedMes
         return None;
     }
     let content_text = text_from_content(message.get("content")?);
-    if content_text.is_empty() {
+    let timestamp = millis_timestamp(record, "time");
+    if content_text.is_empty() || timestamp.is_empty() {
         return None;
     }
     Some(AcceptedMessage {
         role: MessageRole::Assistant,
         content_text,
-        timestamp: millis_timestamp(record, "time"),
+        timestamp,
     })
 }
 

--- a/rust/src/sources/dsh.rs
+++ b/rust/src/sources/dsh.rs
@@ -1,0 +1,341 @@
+use std::path::Path;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::identity::SourceId;
+use crate::model::{MessageRole, SourceKind};
+
+use super::catalog::AcceptedMetadata;
+use super::jsonl::{
+    object, read_bounded_zstd_lines, scan_zstd_json_records, string, timestamp_date,
+};
+use super::{
+    DocumentKind, EmptyProjection, FullProjectionReason, MessageProjection, ProjectedSource,
+    ProjectionCheckpoint, ProjectionMode, ProjectionOutcome, SessionProjection, SourceDocument,
+    SourceError, SourceFile, build_session_summary, fallback_session_id, fallback_timestamp,
+    first_user_title, time_range, truncate_chars,
+};
+
+#[derive(Debug)]
+struct AcceptedSession {
+    session_id: String,
+    cwd: String,
+    timestamp: String,
+}
+
+#[derive(Debug)]
+struct AcceptedMessage {
+    role: MessageRole,
+    content_text: String,
+    timestamp: String,
+}
+
+pub(crate) fn inventory_metadata(path: &Path) -> Result<Option<AcceptedMetadata>, SourceError> {
+    let mut cwd = String::new();
+    let mut path_date = None;
+    let mut accepted_count = 0_usize;
+    let mut hasher = Sha256::new();
+    hasher.update(b"sherlog:dsh:accepted:v1");
+
+    scan_zstd_json_records(path, |record| {
+        if let Some(session) = accepted_session(record) {
+            if cwd.is_empty() {
+                cwd = session.cwd.clone();
+            }
+            if path_date.is_none() {
+                path_date = timestamp_date(&session.timestamp);
+            }
+            hash_fields(
+                &mut hasher,
+                "session",
+                &[&session.session_id, &session.cwd, &session.timestamp],
+            );
+            return true;
+        }
+        if let Some(title) = accepted_title(record) {
+            hash_fields(&mut hasher, "title", &[&title]);
+            return true;
+        }
+        if let Some(model) = accepted_model(record) {
+            hash_fields(&mut hasher, "model", &[&model]);
+            return true;
+        }
+        if let Some(message) = accepted_user_message(record) {
+            accepted_count += 1;
+            if path_date.is_none() {
+                path_date = timestamp_date(&message.timestamp);
+            }
+            hash_fields(
+                &mut hasher,
+                "user",
+                &[&message.timestamp, &message.content_text],
+            );
+            return true;
+        }
+        if let Some(message) = accepted_assistant_message(record) {
+            accepted_count += 1;
+            if path_date.is_none() {
+                path_date = timestamp_date(&message.timestamp);
+            }
+            hash_fields(
+                &mut hasher,
+                "assistant",
+                &[&message.timestamp, &message.content_text],
+            );
+            return true;
+        }
+        true
+    })?;
+
+    Ok((accepted_count > 0).then(|| AcceptedMetadata {
+        cwd,
+        path_date,
+        fingerprint: hex::encode(hasher.finalize()),
+    }))
+}
+
+pub(crate) fn project(
+    file: &SourceFile,
+    read_limit: u64,
+    checkpoint: Option<&ProjectionCheckpoint>,
+) -> Result<ProjectionOutcome, SourceError> {
+    if let Some(checkpoint) = checkpoint {
+        return Ok(ProjectionOutcome::FullRequired {
+            reason: if checkpoint.source_id == SourceId::Dsh {
+                FullProjectionReason::DeltaUnsupported
+            } else {
+                FullProjectionReason::SourceMismatch
+            },
+            read_proof: None,
+        });
+    }
+
+    let mut documents = Vec::new();
+    let mut session_id = String::new();
+    let mut cwd = String::new();
+    let mut model = String::new();
+    let mut session_timestamp = String::new();
+    let mut title = String::new();
+    let read = read_bounded_zstd_lines(file, read_limit, |record| {
+        if let Some(session) = accepted_session(record) {
+            if session_id.is_empty() && !session.session_id.is_empty() {
+                session_id = session.session_id;
+            }
+            if cwd.is_empty() {
+                cwd = session.cwd;
+            }
+            if session_timestamp.is_empty() {
+                session_timestamp = session.timestamp;
+            }
+            return Ok(());
+        }
+        if let Some(candidate) = accepted_title(record)
+            && title.is_empty()
+        {
+            title = candidate;
+            return Ok(());
+        }
+        if let Some(candidate) = accepted_model(record)
+            && model.is_empty()
+        {
+            model = candidate;
+            return Ok(());
+        }
+        let Some(message) =
+            accepted_user_message(record).or_else(|| accepted_assistant_message(record))
+        else {
+            return Ok(());
+        };
+        let seq = documents.len() as i64;
+        documents.push(SourceDocument {
+            kind: DocumentKind::Message,
+            message: MessageProjection {
+                role: message.role,
+                content_text: message.content_text,
+                timestamp: message.timestamp,
+                seq,
+                source_kind: SourceKind::EventMsg,
+            },
+            raw_start: 0,
+            raw_end: 0,
+        });
+        Ok(())
+    })?;
+
+    if read.proof.opened.identity != file.identity {
+        return Ok(ProjectionOutcome::FullRequired {
+            reason: FullProjectionReason::FileIdentityChanged,
+            read_proof: Some(read.proof),
+        });
+    }
+    let checkpoint = ProjectionCheckpoint {
+        source_id: SourceId::Dsh,
+        file_identity: read.proof.opened.identity.clone(),
+        indexed_bytes: read.proof.safe_offset,
+        prefix_digest: read.safe_prefix_digest,
+        next_seq: documents.len() as i64,
+        reducer_state: r#"{"version":1,"mode":"full_only"}"#.to_owned(),
+    };
+    if documents.is_empty() {
+        return Ok(ProjectionOutcome::Skipped(EmptyProjection {
+            read_proof: read.proof,
+            checkpoint,
+        }));
+    }
+
+    let native_session_id = if session_id.is_empty() {
+        fallback_session_id(file)
+    } else {
+        session_id
+    };
+    let session_key = format!("dsh:{native_session_id}");
+    let fallback = fallback_timestamp(file);
+    let additional = std::iter::once(session_timestamp);
+    let (started_at, ended_at) = time_range(&documents, additional, &fallback);
+    let session = SessionProjection {
+        source_id: SourceId::Dsh,
+        native_session_id,
+        session_key: session_key.clone(),
+        session_uuid: session_key,
+        file_path: file.file_path.to_string_lossy().into_owned(),
+        title: if title.is_empty() {
+            first_user_title(&documents).unwrap_or_else(|| "(no title)".to_owned())
+        } else {
+            truncate_chars(&title, 120)
+        },
+        summary_text: build_session_summary(&documents),
+        compact_text: String::new(),
+        reasoning_summary_text: String::new(),
+        cwd: if cwd.is_empty() {
+            file.cwd.clone()
+        } else {
+            cwd
+        },
+        model,
+        started_at,
+        ended_at,
+        document_count: documents.len() as u64,
+    };
+    Ok(ProjectionOutcome::Projected(Box::new(ProjectedSource {
+        mode: ProjectionMode::Full,
+        session,
+        documents,
+        read_proof: read.proof,
+        checkpoint,
+    })))
+}
+
+fn accepted_session(record: &Map<String, Value>) -> Option<AcceptedSession> {
+    if record.get("type").and_then(Value::as_str) != Some("session") {
+        return None;
+    }
+    let cwd = string(record, "cwd");
+    if cwd.is_empty() {
+        return None;
+    }
+    Some(AcceptedSession {
+        session_id: string(record, "id"),
+        cwd,
+        timestamp: millis_timestamp(record, "createdAt"),
+    })
+}
+
+fn accepted_user_message(record: &Map<String, Value>) -> Option<AcceptedMessage> {
+    if record.get("type").and_then(Value::as_str) != Some("user/message") {
+        return None;
+    }
+    let data = object(record, "data")?;
+    let source = object(data, "source")?;
+    if string(source, "kind") != "user" {
+        return None;
+    }
+    let content_text = text_from_content(data.get("content")?);
+    if content_text.is_empty() {
+        return None;
+    }
+    Some(AcceptedMessage {
+        role: MessageRole::User,
+        content_text,
+        timestamp: millis_timestamp(record, "time"),
+    })
+}
+
+fn accepted_assistant_message(record: &Map<String, Value>) -> Option<AcceptedMessage> {
+    if record.get("type").and_then(Value::as_str) != Some("assistant/message") {
+        return None;
+    }
+    let data = object(record, "data")?;
+    let message = object(data, "message")?;
+    if message.get("role").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let content_text = text_from_content(message.get("content")?);
+    if content_text.is_empty() {
+        return None;
+    }
+    Some(AcceptedMessage {
+        role: MessageRole::Assistant,
+        content_text,
+        timestamp: millis_timestamp(record, "time"),
+    })
+}
+
+fn accepted_title(record: &Map<String, Value>) -> Option<String> {
+    if record.get("type").and_then(Value::as_str) != Some("session/title") {
+        return None;
+    }
+    let title = string(object(record, "data")?, "title");
+    (!title.is_empty()).then_some(title)
+}
+
+fn accepted_model(record: &Map<String, Value>) -> Option<String> {
+    if record.get("type").and_then(Value::as_str) != Some("request/header") {
+        return None;
+    }
+    let header = object(object(record, "data")?, "header")?;
+    let config = object(header, "config")?;
+    let model = string(config, "model");
+    (!model.is_empty()).then_some(model)
+}
+
+fn text_from_content(value: &Value) -> String {
+    let Some(items) = value.as_array() else {
+        return String::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            let item = item.as_object()?;
+            if item.get("type").and_then(Value::as_str) != Some("text") {
+                return None;
+            }
+            item.get("text")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn millis_timestamp(record: &Map<String, Value>, key: &str) -> String {
+    let Some(millis) = record.get(key).and_then(Value::as_i64) else {
+        return String::new();
+    };
+    jiff::Timestamp::from_millisecond(millis)
+        .map(|timestamp| timestamp.to_string())
+        .unwrap_or_default()
+}
+
+fn hash_fields(hasher: &mut Sha256, tag: &str, fields: &[&str]) {
+    hash_value(hasher, tag);
+    for field in fields {
+        hash_value(hasher, field);
+    }
+}
+
+fn hash_value(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}

--- a/rust/src/sources/jsonl.rs
+++ b/rust/src/sources/jsonl.rs
@@ -186,12 +186,24 @@ pub(crate) fn scan_json_records(
     Ok(())
 }
 
+/// The zstd read decoder signals a truncated final frame as
+/// `ErrorKind::UnexpectedEof` + "incomplete frame" (zstd stream/raw.rs);
+/// every other decode failure is `ErrorKind::Other` with the C library
+/// error name. Match both halves so corrupt data can never masquerade as a
+/// torn tail.
+fn is_incomplete_zstd_frame(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::UnexpectedEof
+        && error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("incomplete frame")
+}
 /// Metadata scan over a zstd-compressed JSONL file. DSH sessions are stored
 /// as `session.jsonl.zstd`; the adapter treats the compressed file as the raw
 /// source and streams the decompressed records for privacy-reviewed metadata.
 pub(crate) fn scan_zstd_json_records(
     path: &Path,
-    mut callback: impl FnMut(&Map<String, Value>) -> bool,
+    callback: impl FnMut(&Map<String, Value>) -> bool,
 ) -> Result<(), SourceError> {
     let handle = File::open(path).map_err(|source| SourceError::Io {
         operation: "open source metadata",
@@ -203,23 +215,52 @@ pub(crate) fn scan_zstd_json_records(
         path: path.to_path_buf(),
         source,
     })?;
-    let mut reader = BufReader::new(decoder);
+    // Metadata scans only run over fully captured files, so a final
+    // unterminated record (captured between writes) may still be parsed.
+    for_each_zstd_record(decoder, path, "read source metadata", true, callback)
+}
+
+/// Shared zstd JSONL decode loop: streams newline-delimited JSON objects,
+/// skipping blank, malformed, and non-object lines as format drift. When
+/// accept_unterminated_tail is false, a final non-newline-terminated record
+/// is not delivered, keeping projection append-safe. A false return from the
+/// callback stops the scan early.
+fn for_each_zstd_record(
+    reader: impl Read,
+    path: &Path,
+    operation: &'static str,
+    accept_unterminated_tail: bool,
+    mut callback: impl FnMut(&Map<String, Value>) -> bool,
+) -> Result<(), SourceError> {
+    let mut reader = BufReader::new(reader);
     let mut buffer = Vec::new();
 
     loop {
         buffer.clear();
-        let bytes_read =
-            reader
-                .read_until(b'\n', &mut buffer)
-                .map_err(|source| SourceError::Io {
-                    operation: "read source metadata",
+        let bytes_read = match reader.read_until(b'\n', &mut buffer) {
+            Ok(bytes_read) => bytes_read,
+            // A torn final frame (DSH writes sessions incrementally and
+            // repairs torn tails itself) ends the decodable record stream:
+            // project the complete prefix; the next sync replays in full once
+            // the file is repaired. Any other decode failure (corrupt block,
+            // bad frame parameter, ...) stays a hard error.
+            Err(source) if is_incomplete_zstd_frame(&source) => break,
+            Err(source) => {
+                return Err(SourceError::Io {
+                    operation,
                     path: path.to_path_buf(),
                     source,
-                })?;
+                });
+            }
+        };
         if bytes_read == 0 {
             break;
         }
-        let content_len = if buffer.last() == Some(&b'\n') {
+        let newline_terminated = buffer.last() == Some(&b'\n');
+        if !newline_terminated && !accept_unterminated_tail {
+            continue;
+        }
+        let content_len = if newline_terminated {
             content_len_without_newline(&buffer)
         } else {
             buffer.len()
@@ -287,41 +328,23 @@ pub(crate) fn read_bounded_zstd_lines(
                 source,
             }
         })?;
-    let mut reader = BufReader::new(decoder);
-    let mut buffer = Vec::new();
     let mut callback_failure = None;
-
-    loop {
-        buffer.clear();
-        let bytes_read =
-            reader
-                .read_until(b'\n', &mut buffer)
-                .map_err(|source| SourceError::Io {
-                    operation: "read source file",
-                    path: file.file_path.clone(),
-                    source,
-                })?;
-        if bytes_read == 0 {
-            break;
-        }
-        if buffer.last() != Some(&b'\n') {
-            // Unterminated tail is not part of the append-safe projection.
-            continue;
-        }
-        let json = trim_ascii(&buffer[..content_len_without_newline(&buffer)]);
-        if json.is_empty() {
-            continue;
-        }
-        if callback_failure.is_some() {
-            continue;
-        }
-        let Ok(Value::Object(record)) = serde_json::from_slice::<Value>(json) else {
-            continue;
-        };
-        if let Err(reason) = callback(&record) {
-            callback_failure = Some(reason);
-        }
-    }
+    // An unterminated tail is not part of the append-safe projection; after a
+    // callback failure the reader keeps draining to surface late decode errors.
+    for_each_zstd_record(
+        decoder,
+        &file.file_path,
+        "read source file",
+        false,
+        |record| {
+            if callback_failure.is_none() {
+                if let Err(reason) = callback(record) {
+                    callback_failure = Some(reason);
+                }
+            }
+            true
+        },
+    )?;
 
     let completed_metadata = fs::metadata(&file.file_path).map_err(|source| SourceError::Io {
         operation: "stat completed source file",

--- a/rust/src/sources/jsonl.rs
+++ b/rust/src/sources/jsonl.rs
@@ -186,6 +186,166 @@ pub(crate) fn scan_json_records(
     Ok(())
 }
 
+/// Metadata scan over a zstd-compressed JSONL file. DSH sessions are stored
+/// as `session.jsonl.zstd`; the adapter treats the compressed file as the raw
+/// source and streams the decompressed records for privacy-reviewed metadata.
+pub(crate) fn scan_zstd_json_records(
+    path: &Path,
+    mut callback: impl FnMut(&Map<String, Value>) -> bool,
+) -> Result<(), SourceError> {
+    let handle = File::open(path).map_err(|source| SourceError::Io {
+        operation: "open source metadata",
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let decoder = zstd::stream::read::Decoder::new(handle).map_err(|source| SourceError::Io {
+        operation: "decompress source metadata",
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut reader = BufReader::new(decoder);
+    let mut buffer = Vec::new();
+
+    loop {
+        buffer.clear();
+        let bytes_read =
+            reader
+                .read_until(b'\n', &mut buffer)
+                .map_err(|source| SourceError::Io {
+                    operation: "read source metadata",
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if bytes_read == 0 {
+            break;
+        }
+        let content_len = if buffer.last() == Some(&b'\n') {
+            content_len_without_newline(&buffer)
+        } else {
+            buffer.len()
+        };
+        let json = trim_ascii(&buffer[..content_len]);
+        if json.is_empty() {
+            continue;
+        }
+        let Ok(Value::Object(record)) = serde_json::from_slice::<Value>(json) else {
+            continue;
+        };
+        if !callback(&record) {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Full-file projection reader for zstd-compressed JSONL sources.
+///
+/// DSH does not currently support append deltas, so this helper always reads
+/// the full compressed file and verifies the raw compressed prefix. The
+/// decompressed JSONL line offsets are not linear in the compressed file;
+/// source documents therefore use `0` raw locators and `read-*` continues to
+/// serve text from SQLite.
+pub(crate) fn read_bounded_zstd_lines(
+    file: &SourceFile,
+    requested_limit: u64,
+    mut callback: impl FnMut(&Map<String, Value>) -> Result<(), FullProjectionReason>,
+) -> Result<BoundedRead, SourceError> {
+    let handle = File::open(&file.file_path).map_err(|source| SourceError::Io {
+        operation: "open source file",
+        path: file.file_path.clone(),
+        source,
+    })?;
+    let opened_metadata = handle.metadata().map_err(|source| SourceError::Io {
+        operation: "stat opened source file",
+        path: file.file_path.clone(),
+        source,
+    })?;
+    let opened = file_stamp(&file.file_path, &opened_metadata);
+    let effective_limit = requested_limit.min(opened.size);
+
+    // Raw compressed bytes are the source-of-truth proof; decompressed JSONL
+    // offsets are not stable raw offsets for a compressed source.
+    let safe_prefix_digest =
+        super::prefix_sha256(&file.file_path, effective_limit).map_err(|source| {
+            SourceError::Io {
+                operation: "hash compressed source file",
+                path: file.file_path.clone(),
+                source,
+            }
+        })?;
+
+    let handle = File::open(&file.file_path).map_err(|source| SourceError::Io {
+        operation: "open source file",
+        path: file.file_path.clone(),
+        source,
+    })?;
+    let decoder =
+        zstd::stream::read::Decoder::new(handle.take(effective_limit)).map_err(|source| {
+            SourceError::Io {
+                operation: "decompress source file",
+                path: file.file_path.clone(),
+                source,
+            }
+        })?;
+    let mut reader = BufReader::new(decoder);
+    let mut buffer = Vec::new();
+    let mut callback_failure = None;
+
+    loop {
+        buffer.clear();
+        let bytes_read =
+            reader
+                .read_until(b'\n', &mut buffer)
+                .map_err(|source| SourceError::Io {
+                    operation: "read source file",
+                    path: file.file_path.clone(),
+                    source,
+                })?;
+        if bytes_read == 0 {
+            break;
+        }
+        if buffer.last() != Some(&b'\n') {
+            // Unterminated tail is not part of the append-safe projection.
+            continue;
+        }
+        let json = trim_ascii(&buffer[..content_len_without_newline(&buffer)]);
+        if json.is_empty() {
+            continue;
+        }
+        if callback_failure.is_some() {
+            continue;
+        }
+        let Ok(Value::Object(record)) = serde_json::from_slice::<Value>(json) else {
+            continue;
+        };
+        if let Err(reason) = callback(&record) {
+            callback_failure = Some(reason);
+        }
+    }
+
+    let completed_metadata = fs::metadata(&file.file_path).map_err(|source| SourceError::Io {
+        operation: "stat completed source file",
+        path: file.file_path.clone(),
+        source,
+    })?;
+    let completed = file_stamp(&file.file_path, &completed_metadata);
+    Ok(BoundedRead {
+        proof: ReadProof {
+            requested_limit,
+            effective_limit,
+            byte_count: effective_limit,
+            safe_offset: effective_limit,
+            content_fingerprint: safe_prefix_digest.clone(),
+            safe_prefix_fingerprint: safe_prefix_digest.clone(),
+            opened,
+            completed,
+        },
+        safe_prefix_digest,
+        prefix_at_parse: None,
+        callback_failure,
+    })
+}
+
 pub(crate) fn metadata_times(metadata: &Metadata) -> (i128, f64) {
     let nanoseconds = match metadata.modified().and_then(|value| {
         value

--- a/rust/src/sources/mod.rs
+++ b/rust/src/sources/mod.rs
@@ -437,5 +437,20 @@ pub(crate) fn fallback_session_id(file: &SourceFile) -> String {
     format!("{stem}-{}", hex::encode(digest))
 }
 
+/// Test-only writer shared by the source adapter tests and the app e2e
+/// tests so zstd fixtures are encoded exactly one way.
+#[cfg(test)]
+pub(crate) fn write_zstd_lines(path: &std::path::Path, lines: &[String]) {
+    use std::io::Write;
+
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
+    for line in lines {
+        encoder.write_all(line.as_bytes()).unwrap();
+        encoder.write_all(b"\n").unwrap();
+    }
+    let bytes = encoder.finish().unwrap();
+    std::fs::write(path, bytes).unwrap();
+}
+
 #[cfg(test)]
 mod tests;

--- a/rust/src/sources/mod.rs
+++ b/rust/src/sources/mod.rs
@@ -8,6 +8,7 @@
 mod catalog;
 mod claude_code;
 mod codex;
+mod dsh;
 mod jsonl;
 mod pi;
 

--- a/rust/src/sources/tests.rs
+++ b/rust/src/sources/tests.rs
@@ -11,7 +11,7 @@ use crate::selector::Selector;
 
 use super::{
     FullProjectionReason, ProjectedSource, ProjectionMode, ProjectionOutcome, SourceCatalog,
-    SourceFile, SourceMetadataCache, inject_metadata_failure,
+    SourceFile, SourceMetadataCache, inject_metadata_failure, write_zstd_lines,
 };
 
 #[test]
@@ -493,9 +493,12 @@ fn dsh_adapter_accepts_real_messages_and_rejects_injected_context() {
             json!({"type":"session","version":0,"id":"session-dsh-safe","createdAt":1786870711696i64,"cwd":"/safe/dsh"}).to_string(),
             json!({"type":"session/title","seq":1,"time":1786870711696i64,"data":{"title":"accepted dsh title"}}).to_string(),
             json!({"type":"request/header","seq":2,"time":1786870711696i64,"data":{"header":{"config":{"model":"deepseek-v4-flash"}}}}).to_string(),
+            json!({"type":"session/title","seq":7,"time":1786870711701i64,"data":{"title":"refined dsh title"}}).to_string(),
+            json!({"type":"request/header","seq":8,"time":1786870711702i64,"data":{"header":{"config":{"model":"deepseek-v4-pro"}}}}).to_string(),
             json!({"type":"user/message","seq":3,"time":1786870711697i64,"data":{"source":{"kind":"user"},"role":"user","content":[{"type":"text","text":"accepted dsh user"}]}}).to_string(),
             json!({"type":"user/message","seq":4,"time":1786870711698i64,"data":{"source":{"kind":"plugin"},"role":"user","content":[{"type":"text","text":"plugin context must not leak"}]}}).to_string(),
             json!({"type":"user/message","seq":5,"time":1786870711699i64,"data":{"source":{"kind":"skill-catalog"},"role":"user","content":[{"type":"text","text":"skill catalog must not leak"}]}}).to_string(),
+            json!({"type":"user/message","seq":5,"time":1786870711712i64,"data":{"source":{"kind":"agent-instructions"},"role":"user","content":[{"type":"text","text":"agent instructions must not leak"}]}}).to_string(),
             json!({"type":"assistant/message","seq":6,"time":1786870711700i64,"data":{"message":{"role":"assistant","content":[{"type":"reasoning","text":"reasoning must not leak"},{"type":"text","text":"accepted dsh assistant"},{"type":"tool-call","name":"bash","arguments":"tool call must not leak"}]}}}).to_string(),
         ],
     );
@@ -506,8 +509,10 @@ fn dsh_adapter_accepts_real_messages_and_rejects_injected_context() {
     assert_eq!(projected.session.source_id, SourceId::Dsh);
     assert_eq!(projected.session.native_session_id, "session-dsh-safe");
     assert_eq!(projected.session.cwd, "/safe/dsh");
-    assert_eq!(projected.session.model, "deepseek-v4-flash");
-    assert_eq!(projected.session.title, "accepted dsh title");
+    // Latest wins: refined titles and mid-session model switches supersede
+    // the first records.
+    assert_eq!(projected.session.model, "deepseek-v4-pro");
+    assert_eq!(projected.session.title, "refined dsh title");
     assert!(projected.read_proof.stable());
     assert_eq!(projected.read_proof.safe_offset, scan.files[0].size);
     assert!(
@@ -521,18 +526,126 @@ fn dsh_adapter_accepts_real_messages_and_rejects_injected_context() {
     for accepted in [
         "accepted dsh user",
         "accepted dsh assistant",
-        "accepted dsh title",
+        "refined dsh title",
     ] {
         assert!(searchable.contains(accepted), "DSH lost {accepted}");
     }
     for rejected in [
+        // Superseded by the later refined title.
+        "accepted dsh title",
         "plugin context must not leak",
         "skill catalog must not leak",
+        "agent instructions must not leak",
         "reasoning must not leak",
         "tool call must not leak",
     ] {
         assert!(!searchable.contains(rejected), "DSH leaked {rejected}");
     }
+}
+
+#[test]
+fn dsh_adapter_rejects_incomplete_records() {
+    let temp = tempdir().unwrap();
+    let root = temp.path().join("dsh");
+    let session_dir = root.join("session-dsh-incomplete");
+    fs::create_dir_all(&session_dir).unwrap();
+    let file = session_dir.join("session.jsonl.zstd");
+    write_zstd_lines(
+        &file,
+        &[
+            // Missing createdAt: the session record is rejected, so identity
+            // and cwd must fall back instead of carrying an empty timestamp.
+            json!({"type":"session","version":0,"id":"session-dsh-incomplete","cwd":"/incomplete/dsh"}).to_string(),
+            // Missing record time: incomplete messages are rejected.
+            json!({"type":"user/message","seq":1,"data":{"source":{"kind":"user"},"role":"user","content":[{"type":"text","text":"timeless user must not project"}]}}).to_string(),
+            json!({"type":"assistant/message","seq":2,"data":{"message":{"role":"assistant","content":[{"type":"text","text":"timeless assistant must not project"}]}}}).to_string(),
+            json!({"type":"user/message","seq":3,"time":1786870711697i64,"data":{"source":{"kind":"user"},"role":"user","content":[{"type":"text","text":"complete dsh user"}]}}).to_string(),
+        ],
+    );
+
+    let scan = scan_all(SourceId::Dsh, &root);
+    assert_eq!(scan.files.len(), 1);
+    assert!(scan.files[0].cwd.is_empty());
+    let projected = expect_projected(project(&scan.files[0], scan.files[0].size, None));
+    // Without a session record the native id falls back to the session
+    // directory name, not the constant file stem "session.jsonl".
+    assert_eq!(
+        projected.session.native_session_id,
+        "session-dsh-incomplete"
+    );
+    assert!(projected.session.cwd.is_empty());
+    assert_eq!(projected.documents.len(), 1);
+    assert_eq!(
+        projected.documents[0].message.timestamp,
+        "2026-08-16T08:58:31.697Z"
+    );
+    assert_eq!(projected.session.started_at, "2026-08-16T08:58:31.697Z");
+
+    let searchable = serde_json::to_string(&projected).unwrap();
+    assert!(searchable.contains("complete dsh user"));
+    for rejected in [
+        "timeless user must not project",
+        "timeless assistant must not project",
+        "/incomplete/dsh",
+    ] {
+        assert!(!searchable.contains(rejected), "DSH leaked {rejected}");
+    }
+}
+
+#[test]
+fn dsh_adapter_tolerates_torn_final_frame() {
+    let temp = tempdir().unwrap();
+    let root = temp.path().join("dsh");
+    let session_dir = root.join("session-dsh-torn");
+    fs::create_dir_all(&session_dir).unwrap();
+    let file = session_dir.join("session.jsonl.zstd");
+    // A large final record forces the earlier records into completed zstd
+    // blocks, so truncating the frame tail leaves a decodable line prefix.
+    let padding = "x".repeat(200_000);
+    write_zstd_lines(
+        &file,
+        &[
+            json!({"type":"session","version":0,"id":"session-dsh-torn","createdAt":1786870711696i64,"cwd":"/torn/dsh"}).to_string(),
+            json!({"type":"user/message","seq":1,"time":1786870711697i64,"data":{"source":{"kind":"user"},"role":"user","content":[{"type":"text","text":"torn prefix user"}]}}).to_string(),
+            json!({"type":"assistant/message","seq":2,"time":1786870711698i64,"data":{"message":{"role":"assistant","content":[{"type":"text","text":padding}]}}}).to_string(),
+        ],
+    );
+    // Simulate an interrupted in-flight write: cut the compressed frame tail.
+    let bytes = fs::read(&file).unwrap();
+    fs::write(&file, &bytes[..bytes.len() - 7]).unwrap();
+
+    let scan = scan_all(SourceId::Dsh, &root);
+    assert_eq!(scan.files.len(), 1);
+    assert!(scan.failures.is_empty());
+    let projected = expect_projected(project(&scan.files[0], scan.files[0].size, None));
+    let searchable = serde_json::to_string(&projected).unwrap();
+    assert!(searchable.contains("torn prefix user"));
+    assert!(!searchable.contains(&padding));
+}
+
+#[test]
+fn dsh_adapter_rejects_corrupt_frame_header() {
+    let temp = tempdir().unwrap();
+    let root = temp.path().join("dsh");
+    let session_dir = root.join("session-dsh-corrupt");
+    fs::create_dir_all(&session_dir).unwrap();
+    let file = session_dir.join("session.jsonl.zstd");
+    write_zstd_lines(
+        &file,
+        &[
+            json!({"type":"session","version":0,"id":"session-dsh-corrupt","createdAt":1786870711696i64,"cwd":"/corrupt/dsh"}).to_string(),
+            json!({"type":"user/message","seq":1,"time":1786870711697i64,"data":{"source":{"kind":"user"},"role":"user","content":[{"type":"text","text":"corrupt frame must not project"}]}}).to_string(),
+        ],
+    );
+    // Corrupt the frame header (past the 4-byte magic): not a torn tail, so
+    // the failure must stay hard and surface as a scan failure.
+    let mut bytes = fs::read(&file).unwrap();
+    bytes[5] ^= 0xFF;
+    fs::write(&file, &bytes).unwrap();
+
+    let scan = scan_all(SourceId::Dsh, &root);
+    assert!(scan.files.is_empty());
+    assert_eq!(scan.failures.len(), 1);
 }
 
 #[test]
@@ -687,16 +800,6 @@ fn codex_line(record_type: &str, payload: Value) -> String {
 
 fn write_lines(path: &Path, lines: &[String]) {
     fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
-}
-
-fn write_zstd_lines(path: &Path, lines: &[String]) {
-    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
-    for line in lines {
-        encoder.write_all(line.as_bytes()).unwrap();
-        encoder.write_all(b"\n").unwrap();
-    }
-    let bytes = encoder.finish().unwrap();
-    fs::write(path, bytes).unwrap();
 }
 
 fn append(path: &Path, line: &str) {

--- a/rust/src/sources/tests.rs
+++ b/rust/src/sources/tests.rs
@@ -480,6 +480,62 @@ fn codex_checkpoint_projects_only_appended_documents_and_rejects_rewrites() {
 }
 
 #[test]
+fn dsh_adapter_accepts_real_messages_and_rejects_injected_context() {
+    let temp = tempdir().unwrap();
+    let root = temp.path().join("dsh");
+    fs::create_dir_all(&root).unwrap();
+    let session_dir = root.join("session-dsh-safe");
+    fs::create_dir_all(&session_dir).unwrap();
+    let file = session_dir.join("session.jsonl.zstd");
+    write_zstd_lines(
+        &file,
+        &[
+            json!({"type":"session","version":0,"id":"session-dsh-safe","createdAt":1786870711696i64,"cwd":"/safe/dsh"}).to_string(),
+            json!({"type":"session/title","seq":1,"time":1786870711696i64,"data":{"title":"accepted dsh title"}}).to_string(),
+            json!({"type":"request/header","seq":2,"time":1786870711696i64,"data":{"header":{"config":{"model":"deepseek-v4-flash"}}}}).to_string(),
+            json!({"type":"user/message","seq":3,"time":1786870711697i64,"data":{"source":{"kind":"user"},"role":"user","content":[{"type":"text","text":"accepted dsh user"}]}}).to_string(),
+            json!({"type":"user/message","seq":4,"time":1786870711698i64,"data":{"source":{"kind":"plugin"},"role":"user","content":[{"type":"text","text":"plugin context must not leak"}]}}).to_string(),
+            json!({"type":"user/message","seq":5,"time":1786870711699i64,"data":{"source":{"kind":"skill-catalog"},"role":"user","content":[{"type":"text","text":"skill catalog must not leak"}]}}).to_string(),
+            json!({"type":"assistant/message","seq":6,"time":1786870711700i64,"data":{"message":{"role":"assistant","content":[{"type":"reasoning","text":"reasoning must not leak"},{"type":"text","text":"accepted dsh assistant"},{"type":"tool-call","name":"bash","arguments":"tool call must not leak"}]}}}).to_string(),
+        ],
+    );
+
+    let scan = scan_all(SourceId::Dsh, &root);
+    assert_eq!(scan.files.len(), 1);
+    let projected = expect_projected(project(&scan.files[0], scan.files[0].size, None));
+    assert_eq!(projected.session.source_id, SourceId::Dsh);
+    assert_eq!(projected.session.native_session_id, "session-dsh-safe");
+    assert_eq!(projected.session.cwd, "/safe/dsh");
+    assert_eq!(projected.session.model, "deepseek-v4-flash");
+    assert_eq!(projected.session.title, "accepted dsh title");
+    assert!(projected.read_proof.stable());
+    assert_eq!(projected.read_proof.safe_offset, scan.files[0].size);
+    assert!(
+        projected
+            .documents
+            .iter()
+            .all(|document| document.raw_start == 0 && document.raw_end == 0)
+    );
+
+    let searchable = serde_json::to_string(&projected).unwrap();
+    for accepted in [
+        "accepted dsh user",
+        "accepted dsh assistant",
+        "accepted dsh title",
+    ] {
+        assert!(searchable.contains(accepted), "DSH lost {accepted}");
+    }
+    for rejected in [
+        "plugin context must not leak",
+        "skill catalog must not leak",
+        "reasoning must not leak",
+        "tool call must not leak",
+    ] {
+        assert!(!searchable.contains(rejected), "DSH leaked {rejected}");
+    }
+}
+
+#[test]
 fn accepted_digest_does_not_weaken_private_prefix_rewrite_detection() {
     let temp = tempdir().unwrap();
     let root = temp.path().join("2026/08/15");
@@ -631,6 +687,16 @@ fn codex_line(record_type: &str, payload: Value) -> String {
 
 fn write_lines(path: &Path, lines: &[String]) {
     fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
+}
+
+fn write_zstd_lines(path: &Path, lines: &[String]) {
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
+    for line in lines {
+        encoder.write_all(line.as_bytes()).unwrap();
+        encoder.write_all(b"\n").unwrap();
+    }
+    let bytes = encoder.finish().unwrap();
+    fs::write(path, bytes).unwrap();
 }
 
 fn append(path: &Path, line: &str) {

--- a/rust/src/sync/mod.rs
+++ b/rust/src/sync/mod.rs
@@ -1187,7 +1187,13 @@ fn record_scan_failures(
 ) {
     for failure in &scan.failures {
         let path = failure.file_path.to_string_lossy().into_owned();
-        let message = format!("{}: {}", failure.operation, failure.message);
+        // SourceError Display already embeds the operation; only prepend it
+        // for bare messages that lack it.
+        let message = if failure.message.starts_with(&failure.operation) {
+            failure.message.clone()
+        } else {
+            format!("{}: {}", failure.operation, failure.message)
+        };
         if seen.insert((path.clone(), message.clone())) {
             report.record_error(path, message);
         }

--- a/site/index.html
+++ b/site/index.html
@@ -398,7 +398,9 @@ shlog read-range &lt;sessionRef&gt; --seq &lt;matchSeq&gt;</code></pre>
 
   <script>
     async function copyCmd(button) {
-      const text = button.parentElement.querySelector('code').textContent
+      const wrap = button.parentElement;
+      const dataCopy = wrap.getAttribute('data-copy');
+      const text = dataCopy || wrap.querySelector('code').textContent
         .replace(/\\\s*\n\s*/g, ' ')
         .trim();
       try {

--- a/skill-packages/sherlog/SKILL.md
+++ b/skill-packages/sherlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sherlog
-description: "Search local agent-session history to recover prior decisions, commands, configurations, and context from earlier sessions. Use for cross-session recall when the current task depends on what happened in a previous agent conversation. Also use when the user asks in Chinese to recall earlier sessions (e.g. 回忆一下, 之前, 上次, 历史对话). Not for inspecting the current repository or summarizing the current session."
+description: "Search local agent-session history to recover prior decisions, commands, configurations, and context from earlier sessions. Use for cross-session recall when the current task depends on what happened in a previous agent conversation, not for inspecting the current repository or summarizing the current session."
 ---
 
 # Sherlog

--- a/skill-packages/sherlog/SKILL.md
+++ b/skill-packages/sherlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sherlog
-description: "Search local agent-session history to recover prior decisions, commands, configurations, and context from earlier sessions. Use for cross-session recall when the current task depends on what happened in a previous agent conversation, not for inspecting the current repository or summarizing the current session."
+description: "Search local agent-session history to recover prior decisions, commands, configurations, and context from earlier sessions. Use for cross-session recall when the current task depends on what happened in a previous agent conversation. Also use when the user asks in Chinese to recall earlier sessions (e.g. 回忆一下, 之前, 上次, 历史对话). Not for inspecting the current repository or summarizing the current session."
 ---
 
 # Sherlog

--- a/skill-packages/sherlog/references/cli-surface.md
+++ b/skill-packages/sherlog/references/cli-surface.md
@@ -20,7 +20,7 @@
 - **`find` vs `list`**：`find` 按内容召回；`list` 按项目/时间浏览，关键词弱时用。
 - **`list --cwd` vs `find --cwd`**：`list --cwd` 是 case-insensitive metadata substring filter；`find --cwd` 构造 exact cwd selector。两者的 coverage 语义不同，不要混用。
 - **same selector**：`status`、必要的 `sync`、retry 必须用相同 source/root/selector，否则 coverage proof 不匹配。
-- **source-qualified `sessionRef`**：跨 source 读取用 `find` 返回的 `sessionRef`（如 `claude-code:<native-id>`）；bare UUID 被默认按 Codex 解释，不要从 UUID 猜 source。
+- **source-qualified `sessionRef`**：跨 source 读取用 `find` 返回的 `sessionRef`（如 `claude-code:<native-id>`、`dsh:<native-id>`）；bare UUID 被默认按 Codex 解释，不要从 UUID 猜 source。
 - **`--max-message-chars 0`**：正文过长会 elision；关键句不可见时用 0 禁用 elision 读取全文。
 - **strict vs `--best-effort`**：strict 遇错误不发布 complete coverage；`--best-effort` 可提交成功 projection，但带 `errorDetails` 且不表示 complete。
 - **`--prune` / `cold remove`**：破坏性；只在用户明确表达删除意图后执行，普通检索不使用。

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -930,7 +930,7 @@ describe("shlog cli", { timeout: 20_000 }, () => {
       sourceIds: string[];
       results: Array<{ sourceId: string; sessionUuid: string; sessionRef: string; matchSeq: number | null }>;
     };
-    expect(findPayload.sourceIds).toEqual(["codex", "claude-code", "pi"]);
+    expect(findPayload.sourceIds).toEqual(["codex", "claude-code", "pi", "dsh"]);
     expect(findPayload.results.map((result) => result.sourceId).sort()).toEqual(["claude-code", "codex"]);
     const claudeHit = findPayload.results.find((result) => result.sourceId === "claude-code");
     expect(claudeHit?.sessionRef).toBe("claude-code:cli-cross-claude");

--- a/src/selector.test.ts
+++ b/src/selector.test.ts
@@ -32,7 +32,7 @@ describe("selector", () => {
     });
     expect(() =>
       canonicalizeSelector({ source: "unknown", kind: "all", root: "/tmp/cxs-root" })
-    ).toThrow("selector.source must be codex, claude-code, or pi");
+    ).toThrow("selector.source must be codex, claude-code, pi, or dsh");
   });
 
   test("rejects date ranges with fromDate after toDate", () => {

--- a/src/sources/claude-code.test.ts
+++ b/src/sources/claude-code.test.ts
@@ -21,11 +21,12 @@ describe("claude-code source adapter", () => {
 
     expect(adapter.id).toBe("claude-code");
     expect(adapter.public).toBe(true);
-    expect(listSessionSourceAdapters().map((source) => source.id)).toEqual(["codex", "claude-code", "pi"]);
+    expect(listSessionSourceAdapters().map((source) => source.id)).toEqual(["codex", "claude-code", "pi", "dsh"]);
     expect(listSessionSourceAdapters().filter((source) => source.public).map((source) => source.id)).toEqual([
       "codex",
       "claude-code",
       "pi",
+      "dsh",
     ]);
   });
 
@@ -396,6 +397,7 @@ describe("claude-code source adapter", () => {
       "codex",
       "claude-code",
       "pi",
+      "dsh",
     ]);
   });
 });

--- a/src/sources/codex.test.ts
+++ b/src/sources/codex.test.ts
@@ -21,6 +21,7 @@ describe("codex source adapter", () => {
       "codex",
       "claude-code",
       "pi",
+      "dsh",
     ]);
     expect(codexSourceAdapter.public).toBe(true);
   });

--- a/src/sources/dsh.ts
+++ b/src/sources/dsh.ts
@@ -1,0 +1,71 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import type {
+  ParseSessionResult,
+  Selector,
+  SourceFileMeta,
+  SourceInventory,
+  SourceSnapshot,
+} from "../types";
+import type { CollectFilesOptions, SessionSourceAdapter, SourceSnapshotOptions } from "./types";
+
+/**
+ * TypeScript differential oracle does not read zstd-compressed DSH sessions.
+ * The adapter exists so the CLI surface, source selection, and JSON contracts
+ * stay aligned with the native Rust `shlog`; native sync must be used to
+ * populate a database with `dsh` rows. Read-only commands treat DSH as an
+ * empty indexed source rather than crashing cross-source `find`.
+ */
+const EMPTY_INVENTORY: SourceInventory = {
+  root: "",
+  totalFiles: 0,
+  pathDateRange: { from: null, to: null },
+  cwdGroups: [],
+};
+
+export const dshSourceAdapter: SessionSourceAdapter = {
+  id: "dsh",
+  public: true,
+  displayName: "DSH",
+  defaultRoot() {
+    return resolve(homedir(), ".dsh", "sessions");
+  },
+  resolveRoot(override?: string) {
+    return resolve(override ?? this.defaultRoot());
+  },
+  async collectFiles(_root: string, _options?: CollectFilesOptions): Promise<SourceFileMeta[]> {
+    return [];
+  },
+  async inventoryFromFiles(root: string, files: SourceFileMeta[]): Promise<SourceInventory> {
+    return {
+      root,
+      totalFiles: files.length,
+      pathDateRange: { from: null, to: null },
+      cwdGroups: [],
+    };
+  },
+  async snapshotFromFiles(selector: Selector, files: SourceFileMeta[]): Promise<SourceSnapshot> {
+    return {
+      selector,
+      fingerprint: "",
+      fileSetFingerprint: "",
+      fileCount: files.length,
+      files,
+    };
+  },
+  async collectInventory(root: string): Promise<SourceInventory> {
+    return { ...EMPTY_INVENTORY, root };
+  },
+  async collectSnapshot(selector: Selector, _options?: SourceSnapshotOptions): Promise<SourceSnapshot> {
+    return {
+      selector,
+      fingerprint: "",
+      fileSetFingerprint: "",
+      fileCount: 0,
+      files: [],
+    };
+  },
+  async parseFile(_file: SourceFileMeta): Promise<ParseSessionResult> {
+    return { kind: "skipped" };
+  },
+};

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -1,5 +1,6 @@
 export { claudeCodeSourceAdapter } from "./claude-code";
 export { codexSourceAdapter } from "./codex";
+export { dshSourceAdapter } from "./dsh";
 export { piSourceAdapter } from "./pi";
 export { getSessionSourceAdapter, listSessionSourceAdapters } from "./registry";
 export type { SessionSourceAdapter, SessionSourceId } from "./types";

--- a/src/sources/pi.test.ts
+++ b/src/sources/pi.test.ts
@@ -24,11 +24,12 @@ describe("pi source adapter", () => {
     expect(getSessionSourceAdapter().id).toBe("codex");
     expect(adapter.id).toBe("pi");
     expect(adapter.public).toBe(true);
-    expect(listSessionSourceAdapters().map((source) => source.id)).toEqual(["codex", "claude-code", "pi"]);
+    expect(listSessionSourceAdapters().map((source) => source.id)).toEqual(["codex", "claude-code", "pi", "dsh"]);
     expect(listSessionSourceAdapters().filter((source) => source.public).map((source) => source.id)).toEqual([
       "codex",
       "claude-code",
       "pi",
+      "dsh",
     ]);
   });
 

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,5 +1,6 @@
 import { claudeCodeSourceAdapter } from "./claude-code";
 import { codexSourceAdapter } from "./codex";
+import { dshSourceAdapter } from "./dsh";
 import { piSourceAdapter } from "./pi";
 import type { SessionSourceAdapter, SessionSourceId } from "./types";
 
@@ -7,6 +8,7 @@ const adapters = new Map<SessionSourceId, SessionSourceAdapter>([
   [codexSourceAdapter.id, codexSourceAdapter],
   [claudeCodeSourceAdapter.id, claudeCodeSourceAdapter],
   [piSourceAdapter.id, piSourceAdapter],
+  [dshSourceAdapter.id, dshSourceAdapter],
 ]);
 
 export function getSessionSourceAdapter(sourceId: SessionSourceId = "codex"): SessionSourceAdapter {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 export type MessageRole = "user" | "assistant";
 export type MatchSource = "message" | "session";
 export type FindMatchRole = MessageRole | "session";
-export type SessionSourceId = "codex" | "claude-code" | "pi";
+export type SessionSourceId = "codex" | "claude-code" | "pi" | "dsh";
 
 export const DEFAULT_SESSION_SOURCE_ID: SessionSourceId = "codex";
-export const SESSION_SOURCE_IDS = ["codex", "claude-code", "pi"] as const satisfies readonly SessionSourceId[];
+export const SESSION_SOURCE_IDS = ["codex", "claude-code", "pi", "dsh"] as const satisfies readonly SessionSourceId[];
 
 export function isSessionSourceId(value: string): value is SessionSourceId {
   return (SESSION_SOURCE_IDS as readonly string[]).includes(value);


### PR DESCRIPTION
## Summary

Adds a new public source `dsh` to Sherlog so `shlog sync --source dsh` can index zstd-compressed DSH session transcripts under `~/.dsh/sessions`, then search them with `find`, `read-page`, `read-range`, `list`, and `stats`.

## What changed

- `SourceId::Dsh` with `--source dsh` and `dsh:<native-id>` session refs
- Default root: `~/.dsh/sessions`
- zstd JSONL metadata/projection helpers
- New `rust/src/sources/dsh.rs` adapter:
  - Accepts `user/message` only when `data.source.kind == "user"`
  - Accepts `assistant/message` text blocks only
  - Rejects injected plugin/skill-catalog/agent-instructions context, reasoning, tool calls/results
- Full-only projection (`DeltaUnsupported`) like the Pi adapter
- Latest-wins session title/model (first title is a raw paste; model can switch mid-session)
- Shared zstd decode loop tolerates a torn final frame (in-flight writes); corrupt data stays a hard error
- TS differential oracle stub so cross-source `find` remains consistent
- Docs, skill reference, and tests updated

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked --bin shlog`
- `npm run check`
- Release binary smoke with a zstd DSH fixture: sync/find/read-page

