### PR TITLE
chore(release): bump version to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "sherlog-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sherlog-cli"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sherlog-development",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "Eval harness workspace for the native Sherlog CLI",

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -198,6 +198,19 @@
   <main>
     <section>
       <div class="release-header">
+        <span class="release-version">v0.5.2</span>
+        <span class="release-date">2026-08-17</span>
+      </div>
+      <ul class="en">
+        <li><strong>DSH source.</strong> <code>shlog</code> can index and search local DSH session history with <code>--source dsh</code> (experimental), same find/read flow as Codex, Claude Code, and Pi.</li>
+      </ul>
+      <ul class="zh">
+        <li><strong>DSH source。</strong><code>shlog</code> 可用 <code>--source dsh</code> 索引并搜索本机 DSH 会话（实验性），find/read 流程与 Codex、Claude Code、Pi 相同。</li>
+      </ul>
+    </section>
+
+    <section>
+      <div class="release-header">
         <span class="release-version">v0.5.1</span>
         <span class="release-date">2026-08-16</span>
       </div>
@@ -416,8 +429,8 @@
   </main>
 
   <footer>
-    <span class="en">Standalone Rust source &middot; native v0.5.1 published &middot; historical npm releases retained below</span>
-    <span class="zh">Standalone Rust 源码 &middot; 原生 v0.5.1 已发布 &middot; 下方保留历史 npm 版本记录</span>
+    <span class="en">Standalone Rust source &middot; native v0.5.2 published &middot; historical npm releases retained below</span>
+    <span class="zh">Standalone Rust 源码 &middot; 原生 v0.5.2 已发布 &middot; 下方保留历史 npm 版本记录</span>
   </footer>
 
   <script>

--- a/site/index.html
+++ b/site/index.html
@@ -267,14 +267,14 @@
       <span class="zh">搜索本地 Agent 会话历史。</span>
     </div>
     <div class="sub">
-      <span class="en">Search local Codex, Claude Code, and Pi sessions. Standard JSON output.</span>
-      <span class="zh">本地检索 Codex、Claude Code 与 Pi 的 Agent 会话，输出标准 JSON。</span>
+      <span class="en">Search local Codex, Claude Code, Pi, and DSH sessions. Standard JSON output.</span>
+      <span class="zh">本地检索 Codex、Claude Code、Pi 与 DSH 的 Agent 会话，输出标准 JSON。</span>
     </div>
   </header>
 
   <div class="banner">
-    <span class="en"><strong>v0.5.1</strong> &middot; <a href="/changelog">Changelog</a> &middot; <a href="/upgrade">Upgrade</a></span>
-    <span class="zh"><strong>v0.5.1</strong> &middot; <a href="/changelog">更新日志</a> &middot; <a href="/upgrade">升级</a></span>
+    <span class="en"><strong>v0.5.2</strong> &middot; <a href="/changelog">Changelog</a> &middot; <a href="/upgrade">Upgrade</a></span>
+    <span class="zh"><strong>v0.5.2</strong> &middot; <a href="/changelog">更新日志</a> &middot; <a href="/upgrade">升级</a></span>
   </div>
 
   <main>
@@ -388,8 +388,8 @@ shlog read-range &lt;sessionRef&gt; --seq &lt;matchSeq&gt;</code></pre>
   </main>
 
   <footer>
-    <span class="en">v0.5.1</span>
-    <span class="zh">v0.5.1</span>
+    <span class="en">v0.5.2</span>
+    <span class="zh">v0.5.2</span>
     <a href="/changelog"><span class="en">Changelog</span><span class="zh">更新日志</span></a>
     <a href="/upgrade"><span class="en">Upgrade</span><span class="zh">升级迁移</span></a>
     <a href="https://github.com/catoncat/sherlog">GitHub</a>


### PR DESCRIPTION
Bump crate and site to **0.5.2** so a \`v0.5.2\` tag can trigger the native release workflow.

User-facing: experimental \`--source dsh\`.