### PR TITLE
fix(eval): contract gate works with archive-only candidate

### DIFF
--- a/eval/contract-gate.test.ts
+++ b/eval/contract-gate.test.ts
@@ -104,4 +104,17 @@ describe("contract gate helpers", () => {
       "requires an explicit candidate executable override",
     );
   });
+
+  test("reuses the candidate when no checkout shlog exists", () => {
+    const commands = resolveContractExecutables({
+      candidateArgvJson: JSON.stringify(["/tmp/archived-shlog"]),
+      env: {},
+      repoRoot: "/tmp/sherlog-no-checkout-binary",
+    });
+    expect(commands.candidate).toEqual({
+      source: "argv-json",
+      argv: ["/tmp/archived-shlog"],
+    });
+    expect(commands.reference).toEqual(commands.candidate);
+  });
 });

--- a/eval/contract-gate.ts
+++ b/eval/contract-gate.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import packageJson from "../package.json" with { type: "json" };
 import {
+  NativeCliMissingError,
   SHLOG_BIN_UNDER_TEST,
   SHLOG_CLI_ARGV_JSON,
   resolveCliUnderTest,
@@ -51,6 +52,8 @@ export interface ContractGateOptions {
   referenceArgvJson?: string;
   candidateArgvJson?: string;
   env?: NodeJS.ProcessEnv;
+  /** Test-only: override checkout root used to find target/{release,debug}/shlog. */
+  repoRoot?: string;
 }
 
 export interface ContractExecutables {
@@ -131,16 +134,28 @@ interface CaseDefinition {
 
 export function resolveContractExecutables(options: ContractGateOptions = {}): ContractExecutables {
   const env = options.env ?? process.env;
-  const reference = resolveCliUnderTest({
-    ...(options.referenceArgvJson !== undefined ? { argvJson: options.referenceArgvJson } : {}),
-    // Reference ignores ambient candidate env so a leftover SHLOG_BIN does
-    // not silently replace the checkout binary used as the stable side.
-    env: {},
-  });
   const candidate = resolveCliUnderTest({
     ...(options.candidateArgvJson !== undefined ? { argvJson: options.candidateArgvJson } : {}),
     env,
+    repoRoot: options.repoRoot,
   });
+  let reference: CliUnderTest;
+  try {
+    reference = resolveCliUnderTest({
+      ...(options.referenceArgvJson !== undefined ? { argvJson: options.referenceArgvJson } : {}),
+      // Ignore ambient candidate env so SHLOG_BIN cannot silently replace an
+      // explicit checkout binary when one exists.
+      env: {},
+      repoRoot: options.repoRoot,
+    });
+  } catch (error) {
+    if (error instanceof NativeCliMissingError && options.referenceArgvJson === undefined) {
+      // Release/archive jobs only unpack the candidate binary.
+      reference = candidate;
+    } else {
+      throw error;
+    }
+  }
   return { reference, candidate };
 }
 

--- a/eval/run-contract-eval.ts
+++ b/eval/run-contract-eval.ts
@@ -8,14 +8,14 @@ if (argv.includes("--help") || argv.includes("-h")) {
     "Usage: npm run eval:contract -- [options]",
     "",
     "Options:",
-    "  --reference-argv-json '<json-array>'  Override the TypeScript reference command prefix",
+    "  --reference-argv-json '<json-array>'  Override the reference command prefix",
     "  --candidate-argv-json '<json-array>'  Override the candidate command prefix",
-    "  --require-candidate                   Fail instead of falling back to the TypeScript candidate",
+    "  --require-candidate                   Fail unless an explicit candidate is set",
     "  --keep-temp                           Keep fixture and database directories",
     "",
-    "The reference defaults to this checkout's TypeScript CLI. The candidate",
-    "uses explicit argv JSON first, then SHLOG_CLI_ARGV_JSON, then",
-    "SHLOG_BIN_UNDER_TEST, and finally the same TypeScript CLI.",
+    "Both sides default to checkout target/release/shlog (else debug).",
+    "If only the candidate is overridden and no checkout binary exists,",
+    "the reference uses the same candidate (isolated state dirs still differ).",
   ].join("\n"));
   process.exit(0);
 }


### PR DESCRIPTION
v0.5.2 release workflow died here: contract gate reference still demanded \`target/release/shlog\`, but the Linux archive job only has \`./native-contract/shlog\`.

If no checkout binary exists and only the candidate is set, reference now uses that same candidate (two isolated state dirs). Then we can move the \`v0.5.2\` tag and re-run publish.